### PR TITLE
Implement monotonic ULID

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java.
 
-Refer [alizain/ulid](https://github.com/alizain/ulid) for a more detailed ULID specification.
+Refer [ulid/spec](https://github.com/ulid/spec) for a more detailed ULID specification.
 
 ## License
 
@@ -68,6 +68,15 @@ assert ts == 123456789000L;
 byte[] entropy = ULID.getEntropy(ulid);
 ```
 
+Monotonic ULID generation example:
+
+```java
+MonotonicULID ulid = new MonotonicULID();
+String ulid1 = ulid.next();
+String ulid2 = ulid.next();
+String ulid3 = ulid.next();
+```
+
 ## Develop
 
 Please run the following before sending a PR:
@@ -78,4 +87,4 @@ Please run the following before sending a PR:
 ## Prior Art
 
 - [Lewiscowles1986/jULID](https://github.com/Lewiscowles1986/jULID)
-- [alizain/ulid](https://github.com/alizain/ulid)
+- [ulid/spec](https://github.com/ulid/spec)

--- a/src/main/java/io/azam/ulidj/MonotonicULID.java
+++ b/src/main/java/io/azam/ulidj/MonotonicULID.java
@@ -1,0 +1,117 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2016 Azamshul Azizy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.azam.ulidj;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+/**
+ * Monotonic instance of ULID. ULID spec defines monotonicity behavior as if a
+ * ULID is to be generated in the same millisecond, the entropy(random)
+ * component is to be incremented by 1-bit in the least significant bit with
+ * carryover.<br>
+ * <br>
+ * In practice this behavior is however applicable to ULID's generated from the
+ * same source (in Java, from the same instance), else an external
+ * synchronization is needed. Hence, instance of this class will produce ULID in
+ * monotonic order only if called from the same instance.<br>
+ * <br>
+ * Usage example:<br>
+ * <br>
+ *
+ * <pre>
+ * MonotonicULID ulid = new MonotonicULID();
+ * String ulid1 = ulid.next();
+ * String ulid2 = ulid.next();
+ * String ulid3 = ulid.next();
+ * </pre>
+ *
+ * @see <a href="https://github.com/ulid/spec">ULID</a>
+ *
+ * @author azam
+ * @since 1.0.3
+ */
+public class MonotonicULID {
+  private final Random random;
+  private long lastTimestamp;
+  private byte[] lastEntropy;
+
+  /**
+   * Generate a monotonic ULID generator instance, backed by
+   * {@link java.security.SecureRandom} instance.
+   *
+   * @return ULIDMonotonic instance
+   */
+  public MonotonicULID() {
+    this(new SecureRandom());
+  }
+
+  /**
+   * Generate a monotonic ULID generator instance.
+   *
+   * @param random {@link java.util.Random} instance
+   * @return ULIDMonotonic instance
+   */
+  public MonotonicULID(Random random) {
+    if (random == null)
+      throw new IllegalArgumentException("java.util.Random instance must not be null");
+    this.random = random;
+    this.lastEntropy = new byte[ULID.ENTROPY_LENGTH];
+    this.lastTimestamp = -1L;
+  }
+
+  /**
+   * Generate ULID string monotonicly. If this method is called within the same
+   * millisecond, last entropy will be incremented by 1 and the ULID string of
+   * incremented value is returned.<br>
+   * <br>
+   * This method will throw a {@link java.lang.IllegalStateException} exception
+   * if incremented value overflows entropy length (80b-its/10-bytes)
+   *
+   * @return ULID string
+   */
+  public synchronized String generate() {
+    long now = System.currentTimeMillis();
+    if (now == this.lastTimestamp) {
+      // Entropy is big-endian (network byte order) per ULID spec
+      // Increment last entropy by 1
+      boolean carry = true;
+      for (int i = ULID.ENTROPY_LENGTH - 1; i >= 0; i--) {
+        if (carry) {
+          byte work = this.lastEntropy[i];
+          work = (byte) (work + 0x01);
+          carry = this.lastEntropy[i] == (byte) 0xff && carry;
+          this.lastEntropy[i] = work;
+        }
+      }
+      // Last byte has carry over
+      if (carry) {
+        // Throw error if entropy overflows in same millisecond per ULID spec
+        throw new IllegalStateException("ULID entropy overflowed for same millisecond");
+      }
+    } else {
+      // Generate new entropy
+      this.lastTimestamp = now;
+      this.random.nextBytes(this.lastEntropy);
+    }
+    return ULID.generate(this.lastTimestamp, this.lastEntropy);
+  }
+}

--- a/src/main/java/io/azam/ulidj/MonotonicULID.java
+++ b/src/main/java/io/azam/ulidj/MonotonicULID.java
@@ -24,15 +24,13 @@ import java.security.SecureRandom;
 import java.util.Random;
 
 /**
- * Monotonic instance of ULID. ULID spec defines monotonicity behavior as if a
- * ULID is to be generated in the same millisecond, the entropy(random)
- * component is to be incremented by 1-bit in the least significant bit with
- * carryover.<br>
+ * Monotonic instance of ULID. ULID spec defines monotonicity behavior as if a ULID is to be
+ * generated in the same millisecond, the entropy(random) component is to be incremented by 1-bit in
+ * the least significant bit with carryover.<br>
  * <br>
- * In practice this behavior is however applicable to ULID's generated from the
- * same source (in Java, from the same instance), else an external
- * synchronization is needed. Hence, instance of this class will produce ULID in
- * monotonic order only if called from the same instance.<br>
+ * In practice this behavior is however applicable to ULID's generated from the same source (in
+ * Java, from the same instance), else an external synchronization is needed. Hence, instance of
+ * this class will produce ULID in monotonic order only if called from the same instance.<br>
  * <br>
  * Usage example:<br>
  * <br>
@@ -55,10 +53,8 @@ public class MonotonicULID {
   private byte[] lastEntropy;
 
   /**
-   * Generate a monotonic ULID generator instance, backed by
-   * {@link java.security.SecureRandom} instance.
-   *
-   * @return ULIDMonotonic instance
+   * Generate a monotonic ULID generator instance, backed by {@link java.security.SecureRandom}
+   * instance.
    */
   public MonotonicULID() {
     this(new SecureRandom());
@@ -68,7 +64,6 @@ public class MonotonicULID {
    * Generate a monotonic ULID generator instance.
    *
    * @param random {@link java.util.Random} instance
-   * @return ULIDMonotonic instance
    */
   public MonotonicULID(Random random) {
     if (random == null)
@@ -79,12 +74,11 @@ public class MonotonicULID {
   }
 
   /**
-   * Generate ULID string monotonicly. If this method is called within the same
-   * millisecond, last entropy will be incremented by 1 and the ULID string of
-   * incremented value is returned.<br>
+   * Generate ULID string monotonicly. If this method is called within the same millisecond, last
+   * entropy will be incremented by 1 and the ULID string of incremented value is returned.<br>
    * <br>
-   * This method will throw a {@link java.lang.IllegalStateException} exception
-   * if incremented value overflows entropy length (80b-its/10-bytes)
+   * This method will throw a {@link java.lang.IllegalStateException} exception if incremented value
+   * overflows entropy length (80b-its/10-bytes)
    *
    * @return ULID string
    */

--- a/src/main/java/io/azam/ulidj/ULID.java
+++ b/src/main/java/io/azam/ulidj/ULID.java
@@ -23,10 +23,8 @@ package io.azam.ulidj;
 import java.util.Random;
 
 /**
- * ULID string generator and parser class, using Crockford Base32 encoding. Only
- * upper case letters
- * are used for generation. Parsing allows upper and lower case letters, and i
- * and l will be treated
+ * ULID string generator and parser class, using Crockford Base32 encoding. Only upper case letters
+ * are used for generation. Parsing allows upper and lower case letters, and i and l will be treated
  * as 1 and o will be treated as 0. <br>
  * <br>
  * ULID generation examples:<br>
@@ -35,7 +33,7 @@ import java.util.Random;
  * String ulid1 = ULID.random();
  * String ulid2 = ULID.random(ThreadLocalRandom.current());
  * String ulid3 = ULID.random(SecureRandom.newInstance("SHA1PRNG"));
- * byte[] entropy = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9 };
+ * byte[] entropy = new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
  * String ulid4 = ULID.generate(System.currentTimeMillis(), entropy);
  * </pre>
  *
@@ -83,7 +81,8 @@ public class ULID {
       0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, //
       0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, //
       0x47, 0x48, 0x4a, 0x4b, 0x4d, 0x4e, 0x50, 0x51, //
-      0x52, 0x53, 0x54, 0x56, 0x57, 0x58, 0x59, 0x5a };
+      0x52, 0x53, 0x54, 0x56, 0x57, 0x58, 0x59, 0x5a //
+  };
 
   /**
    * {@code char} to {@code byte} O(1) mapping with alternative chars mapping
@@ -180,13 +179,11 @@ public class ULID {
   }
 
   /**
-   * Generate ULID from Unix epoch timestamp in millisecond and entropy bytes.
-   * Throws
-   * {@link java.lang.IllegalArgumentException} if timestamp is less than
-   * {@value #MIN_TIME}, is
+   * Generate ULID from Unix epoch timestamp in millisecond and entropy bytes. Throws
+   * {@link java.lang.IllegalArgumentException} if timestamp is less than {@value #MIN_TIME}, is
    * more than {@value #MAX_TIME}, or entropy bytes is null or less than 10 bytes.
    *
-   * @param time    Unix epoch timestamp in millisecond
+   * @param time Unix epoch timestamp in millisecond
    * @param entropy Entropy bytes
    * @return ULID string
    */
@@ -252,10 +249,8 @@ public class ULID {
   }
 
   /**
-   * Extract and return the timestamp part from ULID. Expects a valid ULID string.
-   * Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before
-   * calling this method
+   * Extract and return the timestamp part from ULID. Expects a valid ULID string. Call
+   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
    * if you do not trust the origin of the ULID string.
    *
    * @param ulid ULID string
@@ -275,10 +270,8 @@ public class ULID {
   }
 
   /**
-   * Extract and return the entropy part from ULID. Expects a valid ULID string.
-   * Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before
-   * calling this method
+   * Extract and return the entropy part from ULID. Expects a valid ULID string. Call
+   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
    * if you do not trust the origin of the ULID string.
    *
    * @param ulid ULID string

--- a/src/main/java/io/azam/ulidj/ULID.java
+++ b/src/main/java/io/azam/ulidj/ULID.java
@@ -23,8 +23,10 @@ package io.azam.ulidj;
 import java.util.Random;
 
 /**
- * ULID string generator and parser class, using Crockford Base32 encoding. Only upper case letters
- * are used for generation. Parsing allows upper and lower case letters, and i and l will be treated
+ * ULID string generator and parser class, using Crockford Base32 encoding. Only
+ * upper case letters
+ * are used for generation. Parsing allows upper and lower case letters, and i
+ * and l will be treated
  * as 1 and o will be treated as 0. <br>
  * <br>
  * ULID generation examples:<br>
@@ -33,7 +35,7 @@ import java.util.Random;
  * String ulid1 = ULID.random();
  * String ulid2 = ULID.random(ThreadLocalRandom.current());
  * String ulid3 = ULID.random(SecureRandom.newInstance("SHA1PRNG"));
- * byte[] entropy = new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
+ * byte[] entropy = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9 };
  * String ulid4 = ULID.generate(System.currentTimeMillis(), entropy);
  * </pre>
  *
@@ -51,13 +53,18 @@ import java.util.Random;
  * @since 0.0.1
  *
  * @see <a href="http://www.crockford.com/wrmg/base32.html">Base32 Encoding</a>
- * @see <a href="https://github.com/alizain/ulid">ULID</a>
+ * @see <a href="https://github.com/ulid/spec">ULID</a>
  */
 public class ULID {
   /**
    * ULID string length.
    */
   public static final int ULID_LENGTH = 26;
+
+  /**
+   * ULID entropy byte length.
+   */
+  public static final int ENTROPY_LENGTH = 10;
 
   /**
    * Minimum allowed timestamp value.
@@ -76,7 +83,7 @@ public class ULID {
       0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, //
       0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, //
       0x47, 0x48, 0x4a, 0x4b, 0x4d, 0x4e, 0x50, 0x51, //
-      0x52, 0x53, 0x54, 0x56, 0x57, 0x58, 0x59, 0x5a};
+      0x52, 0x53, 0x54, 0x56, 0x57, 0x58, 0x59, 0x5a };
 
   /**
    * {@code char} to {@code byte} O(1) mapping with alternative chars mapping
@@ -173,16 +180,18 @@ public class ULID {
   }
 
   /**
-   * Generate ULID from Unix epoch timestamp in millisecond and entropy bytes. Throws
-   * {@link java.lang.IllegalArgumentException} if timestamp is less than {@value #MIN_TIME}, is
+   * Generate ULID from Unix epoch timestamp in millisecond and entropy bytes.
+   * Throws
+   * {@link java.lang.IllegalArgumentException} if timestamp is less than
+   * {@value #MIN_TIME}, is
    * more than {@value #MAX_TIME}, or entropy bytes is null or less than 10 bytes.
    *
-   * @param time Unix epoch timestamp in millisecond
+   * @param time    Unix epoch timestamp in millisecond
    * @param entropy Entropy bytes
    * @return ULID string
    */
   public static String generate(long time, byte[] entropy) {
-    if (time < MIN_TIME || time > MAX_TIME || entropy == null || entropy.length < 10) {
+    if (time < MIN_TIME || time > MAX_TIME || entropy == null || entropy.length < ENTROPY_LENGTH) {
       throw new IllegalArgumentException(
           "Time is too long, or entropy is less than 10 bytes or null");
     }
@@ -243,8 +252,10 @@ public class ULID {
   }
 
   /**
-   * Extract and return the timestamp part from ULID. Expects a valid ULID string. Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
+   * Extract and return the timestamp part from ULID. Expects a valid ULID string.
+   * Call
+   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before
+   * calling this method
    * if you do not trust the origin of the ULID string.
    *
    * @param ulid ULID string
@@ -264,8 +275,10 @@ public class ULID {
   }
 
   /**
-   * Extract and return the entropy part from ULID. Expects a valid ULID string. Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
+   * Extract and return the entropy part from ULID. Expects a valid ULID string.
+   * Call
+   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before
+   * calling this method
    * if you do not trust the origin of the ULID string.
    *
    * @param ulid ULID string

--- a/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
@@ -1,0 +1,202 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2016 Azamshul Azizy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.azam.ulidj;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test class for {@link io.azam.ulidj.MonotonicULID}
+ *
+ * @author azam
+ * @since 1.0.3
+ */
+public class MonotonicULIDTest {
+  @Test
+  public void testConstructor() {
+    Assert.assertNotNull(new MonotonicULID());
+    Assert.assertNotNull(new MonotonicULID(new Random()));
+    Assert.assertNotNull(new MonotonicULID(new SecureRandom()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructorNullRandom() {
+    new MonotonicULID(null);
+  }
+
+  @Test
+  public void testGenerate() {
+    MonotonicULID ulid = new MonotonicULID();
+    String id = ulid.generate();
+    Assert.assertNotNull(id);
+    Assert.assertTrue(ULID.isValid(id));
+  }
+
+  @Test
+  public void testGenerateConcurrent() {
+    MonotonicULID ulid = new MonotonicULID();
+    boolean hasSameTimestamp = false;
+    // This test might not end if we cannot generate multiple ULID in the same
+    // milliseconds. Unless we are running on really slow CPU, we should be OK.
+    while (!hasSameTimestamp) {
+      List<String> values = new ArrayList<String>();
+      // Generate a bunch of ULIDS
+      // Values are inserted in order
+      for (int i = 0; i < 10000; i++) {
+        values.add(ulid.generate());
+      }
+      // Group into timestamp bucket
+      Map<Long, List<byte[]>> groups = new HashMap<Long, List<byte[]>>();
+      for (String value : values) {
+        Assert.assertNotNull(value);
+        Assert.assertTrue(ULID.isValid(value));
+        long ts = ULID.getTimestamp(value);
+        byte[] entropy = ULID.getEntropy(value);
+        if (!groups.containsKey(ts)) {
+          groups.put(ts, new ArrayList<byte[]>());
+        }
+        groups.get(ts).add(entropy);
+      }
+      // For each timestamp bucket check if entropy is monotonic
+      for (long ts : groups.keySet()) {
+        // Loop until we have a bucket of 5 ids on the same timestamp
+        if (groups.get(ts).size() > 4) {
+          // Escape loop on next while eval
+          hasSameTimestamp = true;
+          List<byte[]> bucketValues = groups.get(ts);
+          // Values are inserted in order so we don't have to sort
+          byte[] prev = bucketValues.get(0);
+          for (int i = 1; i < bucketValues.size(); i++) {
+            byte[] curr = bucketValues.get(i);
+            // The next value on the same timestamp is an increment of 1-bit if the previous
+            // value
+            Assert.assertArrayEquals(incrementBytes(prev), curr);
+            prev = curr;
+          }
+        }
+      }
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGenerateOverflow() {
+    // Using a random generator that always return 0xff... so that next increment on
+    // the same timestamp will throw exception
+    MonotonicULID ulid = new MonotonicULID(new FixedRandom(new byte[] { //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
+    }));
+    List<String> values = new ArrayList<String>();
+    //
+    for (int i = 0; i < 1000000; i++) {
+      values.add(ulid.generate());
+    }
+  }
+
+  @Test
+  public void testIncrementBytes() {
+    Assert.assertArrayEquals(new byte[] { //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01 //
+    }, incrementBytes(
+        new byte[] { //
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 //
+        }));
+    Assert.assertArrayEquals(new byte[] { //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
+    }, incrementBytes(
+        new byte[] { //
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xfe //
+        }));
+    Assert.assertArrayEquals(new byte[] { //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00 //
+    }, incrementBytes(
+        new byte[] { //
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
+        }));
+    Assert.assertArrayEquals(new byte[] { //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
+    }, incrementBytes(
+        new byte[] { //
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xfe //
+        }));
+    Assert.assertArrayEquals(null, incrementBytes(
+        new byte[] { //
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
+        }));
+  }
+
+  byte[] incrementBytes(byte[] bytes) {
+    if (bytes == null || bytes.length != ULID.ENTROPY_LENGTH)
+      return null;
+    byte[] value = new byte[ULID.ENTROPY_LENGTH];
+
+    boolean carry = true;
+    for (int i = ULID.ENTROPY_LENGTH - 1; i >= 0; i--) {
+      byte work = bytes[i];
+      if (carry) {
+        work = (byte) (work + 0x01);
+        carry = bytes[i] == (byte) 0xff && carry;
+      }
+      value[i] = work;
+    }
+    // Last byte has carry over
+    if (carry) {
+      return null;
+    }
+
+    return value;
+  }
+
+  class FixedRandom extends Random {
+    private final byte[] bytes;
+
+    public FixedRandom(byte[] bytes) {
+      this.bytes = bytes;
+    }
+
+    @Override
+    public void nextBytes(byte[] out) {
+      for (int i = 0; i < out.length; i++) {
+        if (i < this.bytes.length)
+          out[i] = this.bytes[i];
+        else
+          out[i] = 0x00;
+      }
+    }
+  }
+
+}

--- a/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
@@ -123,40 +123,35 @@ public class MonotonicULIDTest {
     Assert.assertArrayEquals(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01 //
-    }, incrementBytes(
-        new byte[] { //
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 //
-        }));
+    }, incrementBytes(new byte[] { //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 //
+    }));
     Assert.assertArrayEquals(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
-    }, incrementBytes(
-        new byte[] { //
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xfe //
-        }));
+    }, incrementBytes(new byte[] { //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xfe //
+    }));
     Assert.assertArrayEquals(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00 //
-    }, incrementBytes(
-        new byte[] { //
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
-        }));
+    }, incrementBytes(new byte[] { //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
+        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
+    }));
     Assert.assertArrayEquals(new byte[] { //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
-    }, incrementBytes(
-        new byte[] { //
-            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
-            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xfe //
-        }));
-    Assert.assertArrayEquals(null, incrementBytes(
-        new byte[] { //
-            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
-            (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
-        }));
+    }, incrementBytes(new byte[] { //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xfe //
+    }));
+    Assert.assertArrayEquals(null, incrementBytes(new byte[] { //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
+    }));
   }
 
   byte[] incrementBytes(byte[] bytes) {


### PR DESCRIPTION
ULID spec defines a monotonic behavior. This implies some state management of a ULID generator. On this package, it is implemented as `MonotonicULID` class, which is guaranteed to be monotonic as long as it is called from the same instance. Put an instance of it on a singleton/bean to have a ULID generator that is monotonic on your application.

This resolves #6 .