### PR TITLE
Release 1.1.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "java-7-maven",
+    "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "jdkDistro": "tem",
+            "version": "8.0.442",
+            "mavenVersion": "3.8.8",
+            "installMaven": true
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "github.vscode-github-actions"
+            ],
+            "settings": {
+                "telemetry.telemetryLevel": "off",
+                "redhat.telemetry.enabled": false
+            }
+        }
+    }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
    directory: "/"
    schedule:
      interval: weekly
+ - package-ecosystem: "maven"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,29 +35,29 @@ jobs:
       - name: bench-${{matrix.name}}
         # Java 1.7 is source compatible only up to JDK 17
         if: ${{matrix.version<=17}}
-        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=bench-${{matrix.name}}.json -B -V
+        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-${{matrix.name}}.json -B -V
       - name: bench-summary-${{matrix.name}}
         # Java 1.7 is source compatible only up to JDK 17
         if: ${{matrix.version<=17}}
-        run: echo "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
-            && echo "```json\n" >> $GITHUB_STEP_SUMMARY \
-            && cat bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
-            && echo "\n```\n" >> $GITHUB_STEP_SUMMARY
+        run: echo -e "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
+            && echo -e "```json\n" >> $GITHUB_STEP_SUMMARY \
+            && cat ./bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
+            && echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
       - name: bench-as-jdk8-${{matrix.name}}
         if: ${{matrix.version>=8}}
-        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=bench-as-jdk8-${{matrix.name}}.json -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -B -V
+        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk8-${{matrix.name}}.json -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -B -V
       - name: bench-as-jdk8-summary-${{matrix.name}}
         if: ${{matrix.version>=8}}
-        run: echo "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
-            && echo "```json\n" >> $GITHUB_STEP_SUMMARY \
-            && cat bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
-            && echo "\n```\n" >> $GITHUB_STEP_SUMMARY
+        run: echo -e "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
+            && echo -e "```json\n" >> $GITHUB_STEP_SUMMARY \
+            && cat ./bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
+            && echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
       - name: bench-as-jdk21-${{matrix.name}}
         if: ${{matrix.version>=21}}
-        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=bench-as-jdk21-${{matrix.name}}.json -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -B -V
+        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk21-${{matrix.name}}.json -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -B -V
       - name: bench-as-jdk21-summary-${{matrix.name}}
         if: ${{matrix.version>=21}}
         run: echo "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
-            && echo "```json\n" >> $GITHUB_STEP_SUMMARY \
-            && cat bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
-            && echo "\n```\n" >> $GITHUB_STEP_SUMMARY
+            && echo -e "```json\n" >> $GITHUB_STEP_SUMMARY \
+            && cat ./bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
+            && echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,33 +40,27 @@ jobs:
         # Java 1.7 is source compatible only up to JDK 17
         if: ${{matrix.version<=17}}
         run: |
-          pwd
-          ls -al
           echo -e "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
-          echo -e "```json\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "\`\`\`json\n" >> $GITHUB_STEP_SUMMARY
           cat ./bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
-          echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`\n" >> $GITHUB_STEP_SUMMARY
       - name: bench-as-jdk8-${{matrix.name}}
         if: ${{matrix.version>=8}}
         run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk8-${{matrix.name}}.json -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -B -V
       - name: bench-as-jdk8-summary-${{matrix.name}}
         if: ${{matrix.version>=8}}
         run: |
-          pwd
-          ls -al
           echo -e "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
-          echo -e "```json\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "\`\`\`json\n" >> $GITHUB_STEP_SUMMARY
           cat ./bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
-          echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`\n" >> $GITHUB_STEP_SUMMARY
       - name: bench-as-jdk21-${{matrix.name}}
         if: ${{matrix.version>=21}}
         run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk21-${{matrix.name}}.json -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -B -V
       - name: bench-as-jdk21-summary-${{matrix.name}}
         if: ${{matrix.version>=21}}
         run: |
-          pwd
-          ls -al
-          echo "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
-          echo -e "```json\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "\`\`\`json\n" >> $GITHUB_STEP_SUMMARY
           cat ./bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
-          echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`\n" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,63 @@
+name: bench
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  schedule:
+    - cron: '0 9 * * 2'
+  workflow_dispatch:
+
+jobs:
+  bench:
+    name: bench-${{matrix.name}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Oldest LTS
+          - name: temurin-jdk8
+            version: 8
+            distribution: temurin
+          # Latest LTS
+          - name: temurin-jdk21
+            version: 21
+            distribution: temurin
+    steps:
+      - name: checkout-${{matrix.name}}
+        uses: actions/checkout@v4
+      - name: setup-toolchain-${{matrix.name}}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{matrix.version}}
+          distribution: ${{matrix.distribution}}
+          cache: maven
+      - name: bench-${{matrix.name}}
+        # Java 1.7 is source compatible only up to JDK 17
+        if: ${{matrix.version<=17}}
+        run: mvn clean jmh:benchmark -Djmh.rff=json -Djmh.rf=bench-${{matrix.name}}.json -B -V
+      - name: bench-summary-${{matrix.name}}
+        # Java 1.7 is source compatible only up to JDK 17
+        if: ${{matrix.version<=17}}
+        run: echo "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
+            && echo "```json\n" >> $GITHUB_STEP_SUMMARY \
+            && cat bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
+            && echo "\n```\n" >> $GITHUB_STEP_SUMMARY
+      - name: bench-as-jdk8-${{matrix.name}}
+        if: ${{matrix.version>=8}}
+        run: mvn clean jmh:benchmark -Djmh.rff=json -Djmh.rf=bench-as-jdk8-${{matrix.name}}.json -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -B -V
+      - name: bench-as-jdk8-summary-${{matrix.name}}
+        if: ${{matrix.version>=8}}
+        run: echo "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
+            && echo "```json\n" >> $GITHUB_STEP_SUMMARY \
+            && cat bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
+            && echo "\n```\n" >> $GITHUB_STEP_SUMMARY
+      - name: bench-as-jdk21-${{matrix.name}}
+        if: ${{matrix.version>=21}}
+        run: mvn clean jmh:benchmark -Djmh.rff=json -Djmh.rf=bench-as-jdk21-${{matrix.name}}.json -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -B -V
+      - name: bench-as-jdk21-summary-${{matrix.name}}
+        if: ${{matrix.version>=21}}
+        run: echo "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
+            && echo "```json\n" >> $GITHUB_STEP_SUMMARY \
+            && cat bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
+            && echo "\n```\n" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,7 +3,7 @@ name: bench
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
   schedule:
     - cron: '0 9 * * 2'
   workflow_dispatch:
@@ -16,13 +16,37 @@ jobs:
       matrix:
         include:
           # Oldest LTS
-          - name: temurin-jdk8
+          - name: temurin-jdk8-target-jdk7
             version: 8
             distribution: temurin
+            target: 7
+            targetStr: '1.7'
+          - name: temurin-jdk8-target-jdk8
+            version: 8
+            distribution: temurin
+            target: 8
+            targetStr: '1.8'
           # Latest LTS
-          - name: temurin-jdk21
+          - name: temurin-jdk21-target-jdk8
             version: 21
             distribution: temurin
+            target: 8
+            targetStr: '1.8'
+          - name: temurin-jdk21-target-jdk11
+            version: 21
+            distribution: temurin
+            target: 11
+            targetStr: '11'
+          - name: temurin-jdk21-target-jdk17
+            version: 21
+            distribution: temurin
+            target: 17
+            targetStr: '17'
+          - name: temurin-jdk21-target-jdk21
+            version: 21
+            distribution: temurin
+            target: 21
+            targetStr: '21'
     steps:
       - name: checkout-${{matrix.name}}
         uses: actions/checkout@v4
@@ -33,34 +57,34 @@ jobs:
           distribution: ${{matrix.distribution}}
           cache: maven
       - name: bench-${{matrix.name}}
-        # Java 1.7 is source compatible only up to JDK 17
-        if: ${{matrix.version<=17}}
-        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-${{matrix.name}}.json -B -V
-      - name: bench-summary-${{matrix.name}}
-        # Java 1.7 is source compatible only up to JDK 17
-        if: ${{matrix.version<=17}}
+        if: ${{matrix.version >= matrix.target}}
+        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-${{matrix.name}}.json -Dmaven.compiler.source=${{matrix.targetStr}} -Dmaven.compiler.target=${{matrix.targetStr}} -Djacoco.skip=true -B -V
+      - name: bench-step-summary-${{matrix.name}}
+        if: ${{matrix.version >= matrix.target}}
         run: |
           echo -e "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
           echo -e "\`\`\`json\n" >> $GITHUB_STEP_SUMMARY
           cat ./bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
           echo -e "\n\`\`\`\n" >> $GITHUB_STEP_SUMMARY
-      - name: bench-as-jdk8-${{matrix.name}}
-        if: ${{matrix.version>=8}}
-        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk8-${{matrix.name}}.json -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -B -V
-      - name: bench-as-jdk8-summary-${{matrix.name}}
-        if: ${{matrix.version>=8}}
-        run: |
-          echo -e "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
-          echo -e "\`\`\`json\n" >> $GITHUB_STEP_SUMMARY
-          cat ./bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
-          echo -e "\n\`\`\`\n" >> $GITHUB_STEP_SUMMARY
-      - name: bench-as-jdk21-${{matrix.name}}
-        if: ${{matrix.version>=21}}
-        run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk21-${{matrix.name}}.json -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -B -V
-      - name: bench-as-jdk21-summary-${{matrix.name}}
-        if: ${{matrix.version>=21}}
-        run: |
-          echo -e "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
-          echo -e "\`\`\`json\n" >> $GITHUB_STEP_SUMMARY
-          cat ./bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
-          echo -e "\n\`\`\`\n" >> $GITHUB_STEP_SUMMARY
+      - name: bench-pages-branch-${{matrix.name}}
+        if: ${{github.ref_type == 'branch'}}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: branch-${{github.ref_name}}-${{matrix.name}}
+          tool: 'jmh'
+          output-file-path: ./bench-${{matrix.name}}.json
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          auto-push: true
+          summary-always: true
+          benchmark-data-dir-path: 'benchmark/branch/${{github.ref_name}}'
+      - name: bench-pages-tag-${{matrix.name}}
+        if: ${{github.ref_type == 'tag'}}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: tag-${{github.ref_name}}-${{matrix.name}}
+          tool: 'jmh'
+          output-file-path: ./bench-${{matrix.name}}.json
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          auto-push: true
+          summary-always: true
+          benchmark-data-dir-path: 'benchmark/tags'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,25 +39,34 @@ jobs:
       - name: bench-summary-${{matrix.name}}
         # Java 1.7 is source compatible only up to JDK 17
         if: ${{matrix.version<=17}}
-        run: echo -e "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
-            && echo -e "```json\n" >> $GITHUB_STEP_SUMMARY \
-            && cat ./bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
-            && echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
+        run: |
+          pwd
+          ls -al
+          echo -e "## bench-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "```json\n" >> $GITHUB_STEP_SUMMARY
+          cat ./bench-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
+          echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
       - name: bench-as-jdk8-${{matrix.name}}
         if: ${{matrix.version>=8}}
         run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk8-${{matrix.name}}.json -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 -B -V
       - name: bench-as-jdk8-summary-${{matrix.name}}
         if: ${{matrix.version>=8}}
-        run: echo -e "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
-            && echo -e "```json\n" >> $GITHUB_STEP_SUMMARY \
-            && cat ./bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
-            && echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
+        run: |
+          pwd
+          ls -al
+          echo -e "## bench-as-jdk8-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "```json\n" >> $GITHUB_STEP_SUMMARY
+          cat ./bench-as-jdk8-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
+          echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
       - name: bench-as-jdk21-${{matrix.name}}
         if: ${{matrix.version>=21}}
         run: mvn clean jmh:benchmark -Djmh.rf=json -Djmh.rff=./bench-as-jdk21-${{matrix.name}}.json -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -B -V
       - name: bench-as-jdk21-summary-${{matrix.name}}
         if: ${{matrix.version>=21}}
-        run: echo "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY \
-            && echo -e "```json\n" >> $GITHUB_STEP_SUMMARY \
-            && cat ./bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY \
-            && echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY
+        run: |
+          pwd
+          ls -al
+          echo "## bench-as-jdk21-${{matrix.name}}\n\n" >> $GITHUB_STEP_SUMMARY
+          echo -e "```json\n" >> $GITHUB_STEP_SUMMARY
+          cat ./bench-as-jdk21-${{matrix.name}}.json >> $GITHUB_STEP_SUMMARY
+          echo -e "\n```\n" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,34 +18,59 @@ on:
 
 jobs:
   test:
-    name: test-${{matrix.distribution}}-${{matrix.version}}
+    name: test-${{matrix.name}}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name:
-          - jdk8
-          - jdk11
         include:
-          - name: jdk8
+          - name: temurin-jdk8
             version: 8
             distribution: temurin
-          - name: jdk11
+          - name: temurin-jdk11
             version: 11
             distribution: temurin
-          - name: jdk16
-            version: 16
-            distribution: temurin
-          - name: jdk17
+          - name: temurin-jdk17
             version: 17
+            distribution: temurin
+          - name: temurin-jdk21
+            version: 21
+            distribution: temurin
+          # More distribution for latest LTS
+          - name: oracle-jdk21
+            version: 21
+            distribution: oracle
+          - name: corretto-jdk21
+            version: 21
+            distribution: corretto
+          - name: zulu-jdk21
+            version: 21
+            distribution: zulu
+          # Latest versions
+          - name: temurin-jdk22
+            version: 22
             distribution: temurin
     steps:
       - name: checkout-${{matrix.name}}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: setup-toolchain-${{matrix.name}}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{matrix.version}}
           distribution: ${{matrix.distribution}}
           cache: maven
       - name: verify-${{matrix.name}}
+        # Java 1.7 is source compatible only up to JDK 17
+        if: ${{matrix.version<=17}}
         run: mvn verify --settings .settings.xml -Dgpg.skip -B -V
+      - name: verify-as-jdk8-${{matrix.name}}
+        if: ${{matrix.version>=8}}
+        run: mvn verify -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 --settings .settings.xml -Dgpg.skip -B -V
+      - name: verify-as-jdk11-${{matrix.name}}
+        if: ${{matrix.version>=11}}
+        run: mvn verify -Dmaven.compiler.source=11 -Dmaven.compiler.target=11 --settings .settings.xml -Dgpg.skip -B -V
+      - name: verify-as-jdk17-${{matrix.name}}
+        if: ${{matrix.version>=17}}
+        run: mvn verify -Dmaven.compiler.source=17 -Dmaven.compiler.target=17 --settings .settings.xml -Dgpg.skip -B -V
+      - name: verify-as-jdk21-${{matrix.name}}
+        if: ${{matrix.version>=21}}
+        run: mvn verify -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 --settings .settings.xml -Dgpg.skip -B -V

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
       - develop
+      - main-v1
+      - develop-v1
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     types:
       - opened
@@ -68,16 +70,16 @@ jobs:
       - name: verify-${{matrix.name}}
         # Java 1.7 is source compatible only up to JDK 17
         if: ${{matrix.version<=17}}
-        run: mvn verify --settings .settings.xml -Dgpg.skip -B -V
+        run: mvn clean verify --settings .settings.xml -Dgpg.skip -B -V
       - name: verify-as-jdk8-${{matrix.name}}
         if: ${{matrix.version>=8}}
-        run: mvn verify -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 --settings .settings.xml -Dgpg.skip -B -V
+        run: mvn clean verify -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8 --settings .settings.xml -Dgpg.skip -B -V
       - name: verify-as-jdk11-${{matrix.name}}
         if: ${{matrix.version>=11}}
-        run: mvn verify -Dmaven.compiler.source=11 -Dmaven.compiler.target=11 --settings .settings.xml -Dgpg.skip -B -V
+        run: mvn clean verify -Dmaven.compiler.source=11 -Dmaven.compiler.target=11 --settings .settings.xml -Dgpg.skip -B -V
       - name: verify-as-jdk17-${{matrix.name}}
         if: ${{matrix.version>=17}}
-        run: mvn verify -Dmaven.compiler.source=17 -Dmaven.compiler.target=17 --settings .settings.xml -Dgpg.skip -B -V
+        run: mvn clean verify -Dmaven.compiler.source=17 -Dmaven.compiler.target=17 --settings .settings.xml -Dgpg.skip -B -V
       - name: verify-as-jdk21-${{matrix.name}}
         if: ${{matrix.version>=21}}
-        run: mvn verify -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 --settings .settings.xml -Dgpg.skip -B -V
+        run: mvn clean verify -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 --settings .settings.xml -Dgpg.skip -B -V

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,6 @@ jobs:
           - name: temurin-jdk24
             version: 24
             distribution: temurin
-          - name: temurin-jdk25-ea
-            version: 25-ea
-            distribution: temurin
           # Latest LTS version for major JDKs
           - name: oracle-jdk21
             version: 21

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         include:
+          # LTS versions
           - name: temurin-jdk8
             version: 8
             distribution: temurin
@@ -35,7 +36,20 @@ jobs:
           - name: temurin-jdk21
             version: 21
             distribution: temurin
-          # More distribution for latest LTS
+          # Latest versions since last LTS
+          - name: temurin-jdk22
+            version: 22
+            distribution: temurin
+          - name: temurin-jdk23
+            version: 23
+            distribution: temurin
+          - name: temurin-jdk24
+            version: 24
+            distribution: temurin
+          - name: temurin-jdk25-ea
+            version: 25-ea
+            distribution: temurin
+          # Latest LTS version for major JDKs
           - name: oracle-jdk21
             version: 21
             distribution: oracle
@@ -45,10 +59,6 @@ jobs:
           - name: zulu-jdk21
             version: 21
             distribution: zulu
-          # Latest versions
-          - name: temurin-jdk22
-            version: 22
-            distribution: temurin
     steps:
       - name: checkout-${{matrix.name}}
         uses: actions/checkout@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: setup-gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{secrets.MAVEN_GPG_PRIVATE_KEY}}
           passphrase: ${{secrets.MAVEN_GPG_PASSPHRASE}}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
+      - main-v1
       - develop
+      - develop-v1
   workflow_dispatch:
 
 jobs:
@@ -34,4 +36,4 @@ jobs:
           MAVEN_PASSWORD: ${{secrets.MAVEN_PASSWORD}}
           MAVEN_GPG_KEYNAME: ${{secrets.MAVEN_GPG_KEYNAME}}
           MAVEN_GPG_PASSPHRASE: ${{secrets.MAVEN_GPG_PASSPHRASE}}
-        run: mvn package -P release --batch-mode --settings .settings.xml -DskipTests=true -DperformRelease=false -Dmaven.deploy.skip=true --update-snapshots -B -V
+        run: mvn package -P release --batch-mode --settings .settings.xml -Dmaven.test.skip=true -Djacoco.skip=true -DperformRelease=false -Dmaven.deploy.skip=true --update-snapshots -B -V

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,9 +16,9 @@ jobs:
       packages: write
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup-toolchain
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: setup-toolchain
+        if: ${{ !startsWith(github.event.release.tag_name, '1.') }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+          cache: maven
+      - name: setup-toolchain-v1
+        if: ${{ startsWith(github.event.release.tag_name, '1.') }}
         uses: actions/setup-java@v4
         with:
           java-version: 8
@@ -33,7 +41,7 @@ jobs:
           MAVEN_PASSWORD: ${{secrets.MAVEN_PASSWORD}}
           MAVEN_GPG_KEYNAME: ${{secrets.MAVEN_GPG_KEYNAME}}
           MAVEN_GPG_PASSPHRASE: ${{secrets.MAVEN_GPG_PASSPHRASE}}
-        run: mvn deploy -P release --batch-mode --settings .settings.xml -DperformRelease=false --update-snapshots -B -V
+        run: mvn deploy -P release --batch-mode --settings .settings.xml -Dmaven.test.skip=true -Djacoco.skip=true -DperformRelease=false --update-snapshots -B -V
       - name: artifacts
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: setup-gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{secrets.MAVEN_GPG_PRIVATE_KEY}}
           passphrase: ${{secrets.MAVEN_GPG_PASSPHRASE}}
@@ -35,7 +35,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{secrets.MAVEN_GPG_PASSPHRASE}}
         run: mvn deploy -P release --batch-mode --settings .settings.xml -DperformRelease=false --update-snapshots -B -V
       - name: artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             target/ulidj-*.pom

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
       packages: write
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup-toolchain
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: temurin

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,39 @@
+name: package
+
+on:
+  push:
+    branches:
+      - main
+      - main-v1
+      - develop
+      - develop-v1
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup-toolchain
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+          cache: maven
+      - name: site
+        run: mvn clean verify site --settings .settings.xml -Dgpg.skip -B -V
+      - name: publish
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          keep_files: false
+          publish_branch: gh-pages
+          publish_dir: ./target/site
+          destination_dir: 'site/${{github.ref_type}}/${{github.ref_name}}'

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,4 +1,4 @@
-name: package
+name: site
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  package:
+  site:
     name: package
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ buildNumber.properties
 .project
 .settings/
 .vscode/
+.idea/

--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Azamshul Azizy
+Copyright (c) 2016-2025 Azamshul Azizy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6-SNAPSHOT</version>
   <name>ulidj</name>
   <description>ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java.</description>
   <url>https://github.com/azam/ulidj</url>

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <reportSets>
           <reportSet>
             <reports>
-              <report>report-only</report>
+              <report>report</report>
             </reports>
           </reportSet>
         </reportSets>
@@ -324,7 +324,7 @@
         <reportSets>
           <reportSet>
             <reports>
-              <report>report</report>
+              <report>report-only</report>
             </reports>
           </reportSet>
         </reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
           <!-- Setting this to 7 removes unnamed modules found warnings -->
           <!-- Defaults to ${maven.compiler.source} -->
           <!-- <source>7</source> -->
+          <useStandardDocletOptions>false</useStandardDocletOptions>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.5-SNAPSHOT</version>
   <name>ulidj</name>
   <description>ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java.</description>
   <url>https://github.com/azam/ulidj</url>
@@ -15,8 +15,9 @@
     </license>
   </licenses>
   <scm>
-    <url>https://github.com/azam/ulidj</url>
-    <developerConnection>azam</developerConnection>
+    <url>scm:git:git://github.com/azam/ulidj.git</url>
+    <connection>scm:git:git://github.com/azam/ulidj.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com:azam/ulidj.git</developerConnection>
   </scm>
   <developers>
     <developer>
@@ -49,7 +50,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -58,12 +59,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.8.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -76,7 +77,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.2.0</version>
         <configuration>
           <!-- Setting this to 7 removes unnamed modules found warnings -->
           <!-- Defaults to ${maven.compiler.source} -->
@@ -90,6 +91,11 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.2.0</version>
       </plugin>
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,34 @@
     <project.build.lineEnding>LF</project.build.lineEnding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
+    <!-- Benchmark properties -->
+    <jmh.version>1.37</jmh.version>
+    <jmh.benchmarks>Benchmark</jmh.benchmarks>
+    <jmh.bm>AverageTime</jmh.bm>
+    <jmh.tu>ns</jmh.tu>
+    <jmh.r>2</jmh.r>
+    <jmh.f>3</jmh.f>
+    <jmh.wf>1</jmh.wf>
+    <jmh.i>5</jmh.i>
+    <jmh.wi>3</jmh.wi>
   </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -60,6 +82,31 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.openjdk.jmh</groupId>
+              <artifactId>jmh-generator-annprocess</artifactId>
+              <version>${jmh.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.openjdk.jmh</groupId>
+                  <artifactId>jmh-generator-annprocess</artifactId>
+                  <version>${jmh.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -73,6 +120,12 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <!-- https://github.com/metlos/jmh-maven-plugin -->
+      <plugin>
+        <groupId>pw.krejci</groupId>
+        <artifactId>jmh-maven-plugin</artifactId>
+        <version>0.2.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,8 @@
         <version>2.10.4</version>
         <configuration>
           <!-- Setting this to 7 removes unnamed modules found warnings -->
-          <source>7</source>
+          <!-- Defaults to ${maven.compiler.source} -->
+          <!-- <source>7</source> -->
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -66,24 +66,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jacoco</groupId>
       <artifactId>org.jacoco.agent</artifactId>
       <classifier>runtime</classifier>
@@ -160,15 +142,9 @@
         <version>0.8.13</version>
         <executions>
           <execution>
-            <id>jacoco-instrument</id>
+            <id>jacoco-prepare-agent</id>
             <goals>
-              <goal>instrument</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>jacoco-restore-instrumented-classes</id>
-            <goals>
-              <goal>restore-instrumented-classes</goal>
+              <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
@@ -192,7 +168,6 @@
               <goal>check</goal>
             </goals>
             <configuration>
-              <skip>${skipTests}</skip>
               <dataFile>${project.build.directory}/jacoco.exec</dataFile>
               <excludes>
                 <exclude>...</exclude>
@@ -232,7 +207,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.1</version>
         <configuration>
           <!-- Setting this to 7 removes unnamed modules found warnings -->
           <!-- Defaults to ${maven.compiler.source} -->
@@ -328,6 +303,16 @@
             </reports>
           </reportSet>
         </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>3.6.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.1</version>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <name>ulidj</name>
   <description>ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java.</description>
   <url>https://github.com/azam/ulidj</url>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
           <!-- Setting this to 7 removes unnamed modules found warnings -->
           <!-- Defaults to ${maven.compiler.source} -->
           <!-- <source>7</source> -->
-          <useStandardDocletOptions>false</useStandardDocletOptions>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>ulidj</name>
   <description>ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java.</description>
   <url>https://github.com/azam/ulidj</url>
   <licenses>
     <license>
       <name>The MIT License (MIT)</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/license/MIT</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -25,7 +25,7 @@
       <name>azam</name>
       <email>azamshul@gmail.com</email>
       <organization>azam.io</organization>
-      <organizationUrl>http://azam.io</organizationUrl>
+      <organizationUrl>https://azam.io</organizationUrl>
       <roles>
         <role>Geek</role>
       </roles>
@@ -43,6 +43,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.lineEnding>LF</project.build.lineEnding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <!-- Benchmark properties -->
@@ -62,6 +63,31 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <version>0.8.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -129,6 +155,81 @@
         <version>0.2.2</version>
       </plugin>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.13</version>
+        <executions>
+          <execution>
+            <id>jacoco-instrument</id>
+            <goals>
+              <goal>instrument</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-restore-instrumented-classes</id>
+            <goals>
+              <goal>restore-instrumented-classes</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+              <formats>
+                <format>HTML</format>
+                <format>XML</format>
+                <format>CSV</format>
+              </formats>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+              <excludes>
+                <exclude>...</exclude>
+              </excludes>
+              <haltOnFailure>false</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.90</minimum>
+                    </limit>
+                    <limit >
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.75</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.3</version>
+        <configuration>
+          <systemPropertyVariables>
+            <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
@@ -150,6 +251,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-help-plugin</artifactId>
         <version>3.2.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.21.0</version>
       </plugin>
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
@@ -180,6 +286,9 @@
         <artifactId>xml-format-maven-plugin</artifactId>
         <version>3.2.2</version>
         <configuration>
+          <includes>pom.xml</includes>
+          <includes>.settings.xml</includes>
+          <includes>eclipse-java-google-style.xml</includes>
           <indentSize>2</indentSize>
         </configuration>
         <executions>
@@ -194,6 +303,34 @@
       </plugin>
     </plugins>
   </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.13</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>report-only</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+        <version>3.5.3</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.5-SNAPSHOT</version>
+  <version>1.0.5</version>
   <name>ulidj</name>
   <description>ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java.</description>
   <url>https://github.com/azam/ulidj</url>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <jmh.bm>AverageTime</jmh.bm>
     <jmh.tu>ns</jmh.tu>
     <jmh.r>2</jmh.r>
+    <jmh.w>2</jmh.w>
     <jmh.f>3</jmh.f>
     <jmh.wf>1</jmh.wf>
     <jmh.i>5</jmh.i>

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,8 @@ ULID (Universally Unique Lexicographically Sortable Identifier) generator and pa
 
 ## Features
 
-* Generates ULID to `String` (Crockford's base32) or `byte[]` (128-bit UUID compatible) objects
-* Parses ULID from `String` (Crockford's base32) or `byte[]` (128-bit UUID compatible) objects
+* Generates ULID to `String` (Crockford's base32) or `byte[]` (128-bit binary) objects
+* Parses ULID from `String` (Crockford's base32) or `byte[]` (128-bit binary) objects
 * Fast and simple static methods
 * Includes ULID monotonic generator
 * Zero runtime dependencies
@@ -49,7 +49,7 @@ Add the following tag to `dependencies` tag in your `pom.xml` file. Change the v
 <dependency>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
 </dependency>
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -7,20 +7,26 @@
 
 ULID (Universally Unique Lexicographically Sortable Identifier) generator and parser for Java. Refer [ulid/spec](https://github.com/ulid/spec) for a more detailed ULID specification.
 
+Version 2.x targets JDK 11, and peruse newer functions such as `java.time.Clock` and module declarations.
+
+Version 1.x targets JDK 1.7, and is functionally equals to version 2.x without the extended support for `java.time.Clock` and module declarations.
+
 ## Features
 
 * Generates ULID to `String` (Crockford's base32) or `byte[]` (128-bit binary) objects
 * Parses ULID from `String` (Crockford's base32) or `byte[]` (128-bit binary) objects
-* Fast and simple static methods
+* Fast and simple static methods for non-monotonic ULID (monotonic ULID is stateful)
 * Includes ULID monotonic generator
 * Zero runtime dependencies
+* Customizable by providing your own `java.util.Random` instance for entropy
+* Full test coverage, performant, battle-tested, and production-ready
 
 ## License
 
 ```
 MIT License
 
-Copyright (c) 2016 Azamshul Azizy
+Copyright (c) 2016-2025 Azamshul Azizy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +55,7 @@ Add the following tag to `dependencies` tag in your `pom.xml` file. Change the v
 <dependency>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.6</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -58,9 +64,17 @@ Add the following tag to `dependencies` tag in your `pom.xml` file. Change the v
 ULID generation examples:
 
 ```java
+// Random ULID generation
 String ulid1 = ULID.random();
 String ulid2 = ULID.random(ThreadLocalRandom.current());
 String ulid3 = ULID.random(SecureRandom.newInstance("SHA1PRNG"));
+
+// Random binary ULID generation
+String ulid1Binary = ULID.randomBinary();
+String ulid2Binary = ULID.randomBinary(ThreadLocalRandom.current());
+String ulid3Binary = ULID.randomBinary(SecureRandom.newInstance("SHA1PRNG"));
+
+// Custom ULID generation
 byte[] entropy = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9 };
 String ulid4 = ULID.generate(System.currentTimeMillis(), entropy); // Generate ULID in string representation
 byte[] ulid5 = ULID.generateBinary(System.currentTimeMillis(), entropy); // Generate ULID in binary representation
@@ -72,9 +86,9 @@ ULID parsing examples:
 // ULID string parsing
 String ulid = "003JZ9J6G80123456789abcdef";
 assert ULID.isValid(ulid);
-long ts = ULID.getTimestamp(ulid);
+long ts = ULID.getTimestamp(ulid); // Get UTC timestamp in milliseconds
 assert ts == 123456789000L;
-byte[] entropy = ULID.getEntropy(ulid);
+byte[] entropy = ULID.getEntropy(ulid); // Get entropy part
 
 // ULID binary parsing
 byte[] ulidBinary =  new byte[] { //
@@ -84,17 +98,23 @@ byte[] ulidBinary =  new byte[] { //
     (byte) 0x10, (byte) 0x20, (byte) 0x30, (byte) 0x40, (byte) 0x50, (byte) 0x60, (byte) 0x70, (byte) 0x80, (byte) 0x90, (byte) 0x10 //
 };
 assert ULID.isValidBinary(ulidBinary);
-long ts = ULID.getTimestampBinary(ulidBinary);
+long ts = ULID.getTimestampBinary(ulidBinary); // Get UTC timestamp in milliseconds
 assert ts == 1320636247808L;
-byte[] entropy = ULID.getEntropyBinary(ulidBinary);
+byte[] entropy = ULID.getEntropyBinary(ulidBinary); // Get entropy part
 ```
 
 Monotonic ULID generation example:
 
 ```java
+// Monotonic ULID geneation
 MonotonicULID ulid = new MonotonicULID();
 String ulidString = ulid.generate(); // Generate ULID in string representation
 byte[] ulidBinary = ulid.generateBinary(); // Generate ULID in binary representation
+
+// Monotonic ULID geneation with custom random generator
+MonotonicULID ulidSecure = new MonotonicULID(SecureRandom.newInstance("SHA1PRNG"));
+String ulidSecureString = ulid.generate(); // Generate ULID in string representation
+byte[] ulidSecureBinary = ulid.generateBinary(); // Generate ULID in binary representation
 ```
 
 ## Develop

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Add the following tag to `dependencies` tag in your `pom.xml` file. Change the v
 <dependency>
   <groupId>io.azam.ulidj</groupId>
   <artifactId>ulidj</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
 </dependency>
 ```
 

--- a/src/main/java/io/azam/ulidj/MonotonicULID.java
+++ b/src/main/java/io/azam/ulidj/MonotonicULID.java
@@ -1,7 +1,7 @@
-/**
+/*
  * MIT License
  *
- * Copyright (c) 2016 Azamshul Azizy
+ * Copyright (c) 2016-2025 Azamshul Azizy
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -27,100 +27,139 @@ import java.util.Random;
  * Monotonic instance of ULID. ULID spec defines monotonicity behavior as if a ULID is to be
  * generated in the same millisecond, the entropy(random) component is to be incremented by 1-bit in
  * the least significant bit with carryover.<br>
- * <br>
+ *
  * In practice this behavior is however applicable to ULID's generated from the same source (in
  * Java, from the same instance), else an external synchronization is needed. Hence, instance of
- * this class will produce ULID in monotonic order only if called from the same instance.<br>
- * <br>
+ * this class will produce ULID in monotonic order only if called from the same instance, e.g. from
+ * a singleton Bean.<br>
+ *
  * Usage example:<br>
- * <br>
  *
  * <pre>
  * MonotonicULID ulid = new MonotonicULID();
- * String ulid1 = ulid.next();
- * String ulid2 = ulid.next();
- * String ulid3 = ulid.next();
+ * String ulid1 = ulid.generate();
+ * String ulid2 = ulid.generate();
+ * String ulid3 = ulid.generate();
+ * byte[] ulid4 = ulid.generateBinary();
+ * ULID ulid5 = ulid.generateULID();
  * </pre>
  *
  * @see <a href="https://github.com/ulid/spec">ULID</a>
  *
  * @author azam
  * @since 1.0.3
+ *
+ * @see <a href="https://github.com/azam">ulidj</a>
+ * @see <a href="https://github.com/ulid/spec">ULID Specification</a>
+ * @see <a href="https://www.crockford.com/wrmg/base32.html">Crockford Base32 Encoding</a>
  */
 public class MonotonicULID {
   private final Random random;
+  private final byte[] lastEntropy;
   private long lastTimestamp;
-  private byte[] lastEntropy;
 
   /**
-   * Generate a monotonic ULID generator instance, backed by {@link java.security.SecureRandom}
-   * instance.
+   * This allows lazy initialization of the default {@link java.util.Random} instance, backed by
+   * {@link java.security.SecureRandom} instance.
+   *
+   * @since 1.1.0
+   */
+  private static class LazyDefaults {
+    /**
+     * Default {@link java.util.Random} instance.
+     *
+     * @since 1.1.0
+     */
+    static final Random random = new SecureRandom();
+  }
+
+  /**
+   * Generate a monotonic ULID generator instance using default {@link java.util.Random} instance
+   * backed by {@link java.security.SecureRandom}.
+   *
+   * @since 1.0.3
    */
   public MonotonicULID() {
-    this(new SecureRandom());
+    this(LazyDefaults.random);
   }
 
   /**
    * Generate a monotonic ULID generator instance.
    *
    * @param random {@link java.util.Random} instance
+   * @since 1.0.3
    */
   public MonotonicULID(Random random) {
-    if (random == null)
-      throw new IllegalArgumentException("java.util.Random instance must not be null");
-    this.random = random;
+    this.random = random == null ? LazyDefaults.random : random;
     this.lastEntropy = new byte[ULID.ENTROPY_LENGTH];
-    this.lastTimestamp = -1L;
+    this.lastTimestamp = 0L;
   }
 
   /**
-   * Generate ULID string monotonicly. If this method is called within the same millisecond, last
+   * Generate ULID string monotonically. If this method is called within the same millisecond, last
    * entropy will be incremented by 1 and the ULID string of incremented value is returned.<br>
    * <br>
    * This method will throw a {@link java.lang.IllegalStateException} exception if incremented value
-   * overflows entropy length (80b-its/10-bytes)
+   * overflows entropy length (80-bits/10-bytes)
    *
    * @return ULID string
+   * @throws IllegalStateException if time is out of ULID specification or entropy overflowed
+   * @since 1.0.3
    */
   public synchronized String generate() {
-    long now = System.currentTimeMillis();
-    if (now == this.lastTimestamp) {
-      // Entropy is big-endian (network byte order) per ULID spec
-      // Increment last entropy by 1
-      boolean carry = true;
-      for (int i = ULID.ENTROPY_LENGTH - 1; i >= 0; i--) {
-        if (carry) {
-          byte work = this.lastEntropy[i];
-          work = (byte) (work + 0x01);
-          carry = this.lastEntropy[i] == (byte) 0xff && carry;
-          this.lastEntropy[i] = work;
-        }
-      }
-      // Last byte has carry over
-      if (carry) {
-        // Throw error if entropy overflows in same millisecond per ULID spec
-        throw new IllegalStateException("ULID entropy overflowed for same millisecond");
-      }
-    } else {
-      // Generate new entropy
-      this.lastTimestamp = now;
-      this.random.nextBytes(this.lastEntropy);
-    }
+    mutate();
     return ULID.generate(this.lastTimestamp, this.lastEntropy);
   }
 
   /**
-   * Generate ULID binary monotonicly. If this method is called within the same millisecond, last
+   * Generate ULID binary monotonically. If this method is called within the same millisecond, last
    * entropy will be incremented by 1 and the ULID string of incremented value is returned.<br>
    * <br>
    * This method will throw a {@link java.lang.IllegalStateException} exception if incremented value
-   * overflows entropy length (80b-its/10-bytes)
+   * overflows entropy length (80-bits/10-bytes)
    *
    * @return ULID binary
+   * @throws IllegalStateException if time is out of ULID specification or entropy overflowed
+   * @since 1.0.4
    */
   public synchronized byte[] generateBinary() {
+    mutate();
+    return ULID.generateBinary(this.lastTimestamp, this.lastEntropy);
+  }
+
+  /**
+   * Generate ULID instance monotonically. If this method is called within the same millisecond,
+   * last entropy will be incremented by 1 and the ULID string of incremented value is returned.<br>
+   * <br>
+   * This method will throw a {@link java.lang.IllegalStateException} exception if incremented value
+   * overflows entropy length (80-bits/10-bytes)
+   *
+   * @return ULID instance
+   * @throws IllegalStateException if time is out of ULID specification or entropy overflowed
+   * @since 1.1.0
+   */
+  public synchronized ULID generateULID() {
+    mutate();
+    return ULID.generateULID(this.lastTimestamp, this.lastEntropy);
+  }
+
+  /**
+   * Check if the last timestamp is less than the current time. If so, generate new entropy
+   * otherwise increment the last entropy by 1-bit in the least significant bit with carryover. If
+   * the last entropy overflows, revert to the previous value and throw an exception.
+   *
+   * @throws IllegalStateException if time is out of ULID specification or entropy overflowed
+   * @since 1.1.0
+   */
+  private void mutate() {
     long now = System.currentTimeMillis();
-    if (now == this.lastTimestamp) {
+    if (now < ULID.MIN_TIME || now > ULID.MAX_TIME)
+      throw new IllegalStateException("Time is out of ULID specification");
+    if (now <= this.lastTimestamp) {
+      // Keep last timestamp and increment last entropy
+      // Save a copy of last entropy in case of entropy overflow
+      byte[] previousEntropy = new byte[ULID.ENTROPY_LENGTH];
+      System.arraycopy(this.lastEntropy, 0, previousEntropy, 0, ULID.ENTROPY_LENGTH);
       // Entropy is big-endian (network byte order) per ULID spec
       // Increment last entropy by 1
       boolean carry = true;
@@ -128,12 +167,14 @@ public class MonotonicULID {
         if (carry) {
           byte work = this.lastEntropy[i];
           work = (byte) (work + 0x01);
-          carry = this.lastEntropy[i] == (byte) 0xff && carry;
+          carry = this.lastEntropy[i] == (byte) 0xff;
           this.lastEntropy[i] = work;
         }
       }
       // Last byte has carry over
       if (carry) {
+        // Revert last entropy to previous value
+        System.arraycopy(previousEntropy, 0, this.lastEntropy, 0, ULID.ENTROPY_LENGTH);
         // Throw error if entropy overflows in same millisecond per ULID spec
         throw new IllegalStateException("ULID entropy overflowed for same millisecond");
       }
@@ -142,6 +183,5 @@ public class MonotonicULID {
       this.lastTimestamp = now;
       this.random.nextBytes(this.lastEntropy);
     }
-    return ULID.generateBinary(this.lastTimestamp, this.lastEntropy);
   }
 }

--- a/src/main/java/io/azam/ulidj/ULID.java
+++ b/src/main/java/io/azam/ulidj/ULID.java
@@ -1,7 +1,7 @@
-/**
+/*
  * MIT License
  *
- * Copyright (c) 2016 Azamshul Azizy
+ * Copyright (c) 2016-2025 Azamshul Azizy
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -20,14 +20,28 @@
  */
 package io.azam.ulidj;
 
+import java.io.Serializable;
+import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Random;
 
 /**
  * ULID string generator and parser class, using Crockford Base32 encoding. Only upper case letters
  * are used for generation. Parsing allows upper and lower case letters, and i and l will be treated
  * as 1 and o will be treated as 0. <br>
- * <br>
- * ULID generation examples:<br>
+ *
+ * ULID immutable sortable (implements {@link java.lang.Comparable}) valid instance generation. <br>
+ *
+ * <pre>
+ * ULID ulid1 = ULID.randomULID();
+ * ULID ulid2 = ULID.randomULID(ThreadLocalRandom.current());
+ * ULID ulid3 = ULID.parseULID("003JZ9J6G80123456789abcdef");
+ * ULID ulid4 = ULID.parseULID(
+ *     new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf});
+ * ULID ulid5 = ULID.generateULID(System.currentTimeMillis(), entropy);
+ * </pre>
+ *
+ * ULID string generation examples:<br>
  *
  * <pre>
  * String ulid1 = ULID.random();
@@ -45,43 +59,90 @@ import java.util.Random;
  * long ts = ULID.getTimestamp(ulid);
  * assert ts == 123456789000L;
  * byte[] entropy = ULID.getEntropy(ulid);
+ *
+ * byte[] ulidBinary =
+ *     new byte[] {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf};
+ * assert ULID.isValidBinary(ulidBinary);
+ * long tsBinary = ULID.getTimestampBinary(ulidBinary);
+ * assert tsBinary == 1L;
+ * byte[] entropyBinary = ULID.getEntropyBinary(ulidBinary);
+ * </pre>
+ *
+ * ULID string representation:<br>
+ *
+ * <pre>
+ *  01AN4Z07BY      79KA1307SR9X4MV3
+ * |----------|    |----------------|
+ *  Timestamp          Randomness
+ *    48bits             80bits
+ * </pre>
+ *
+ * ULID binary representation:<br>
+ *
+ * <pre>
+ * |0                   1                   2                   3  |
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                      32_bit_uint_time_high                    |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |     16_bit_uint_time_low      |       16_bit_uint_random      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                       32_bit_uint_random                      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                       32_bit_uint_random                      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * </pre>
  *
  * @author azam
  * @since 0.0.1
  *
- * @see <a href="http://www.crockford.com/wrmg/base32.html">Base32 Encoding</a>
- * @see <a href="https://github.com/ulid/spec">ULID</a>
+ * @see <a href="https://github.com/azam">ulidj</a>
+ * @see <a href="https://github.com/ulid/spec">ULID Specification</a>
+ * @see <a href="https://www.crockford.com/wrmg/base32.html">Crockford Base32 Encoding</a>
  */
-public class ULID {
+public final class ULID implements Serializable, Comparable<ULID> {
+  private static final long serialVersionUID = 1L;
+
   /**
    * ULID string length.
+   *
+   * @since 0.0.1
    */
   public static final int ULID_LENGTH = 26;
 
   /**
    * ULID binary length.
+   *
+   * @since 1.0.4
    */
   public static final int ULID_BINARY_LENGTH = 16;
 
   /**
    * ULID entropy byte length.
+   *
+   * @since 1.0.3
    */
   public static final int ENTROPY_LENGTH = 10;
 
   /**
    * Minimum allowed timestamp value.
+   *
+   * @since 0.0.1
    */
   public static final long MIN_TIME = 0x0L;
 
   /**
    * Maximum allowed timestamp value. Encoded value can encode up to 0x0003ffffffffffffL but ULID
    * binary/byte representation states that timestamp will only be 48-bits.
+   *
+   * @since 0.0.1
    */
   public static final long MAX_TIME = 0x0000ffffffffffffL;
 
   /**
    * Base32 characters mapping
+   *
+   * @since 0.0.1
    */
   private static final char[] C = new char[] { //
       0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, //
@@ -161,27 +222,210 @@ public class ULID {
   };
 
   /**
-   * Generate random ULID string using {@link java.util.Random} instance.
+   * This allows lazy initialization of the default {@link java.util.Random} instance, backed by
+   * {@link java.security.SecureRandom} instance.
+   *
+   * @since 1.1.0
+   */
+  private static class LazyDefaults {
+    /**
+     * Default {@link java.util.Random} instance.
+     *
+     * @since 1.1.0
+     */
+    static final Random random = new SecureRandom();
+  }
+
+  private final byte[] binary;
+
+  /**
+   * ULID no argument constructor is private to prevent instantiation and finalizing attacks.
+   *
+   * @since 1.1.0
+   */
+  private ULID() {
+    throw new UnsupportedOperationException("Use randomULID() or randomBinary() to generate ULID");
+  }
+
+  /**
+   * Constructs an immutable ULID instance using provided ULID binary byte array.
+   *
+   * @param value ULID binary
+   * @throws IllegalArgumentException if the ULID binary byte array is not valid
+   * @since 1.1.0
+   */
+  private ULID(byte[] value) {
+    this.binary = Arrays.copyOf(value, ULID_BINARY_LENGTH);
+  }
+
+  /**
+   * Extract and return the timestamp part of this ULID instance.
+   *
+   * @return Unix epoch timestamp in millisecond
+   * @since 1.1.0
+   */
+  public long getTimestamp() {
+    return getTimestampBinary(this.binary);
+  }
+
+  /**
+   * Extract and return the entropy part of this ULID instance.
+   *
+   * @return Entropy bytes
+   * @since 1.1.0
+   */
+  public byte[] getEntropy() {
+    return getEntropyBinary(this.binary);
+  }
+
+  /**
+   * Convert this ULID instance to its ULID binary representation.
+   *
+   * @return ULID binary
+   * @since 1.1.0
+   */
+  public byte[] toBinary() {
+    return Arrays.copyOf(this.binary, ULID_BINARY_LENGTH);
+  }
+
+  /**
+   * Convert this ULID instance to its ULID string representation.
    *
    * @return ULID string
+   * @since 1.1.0
+   */
+  @Override
+  public String toString() {
+    return fromBinary(this.binary);
+  }
+
+  /**
+   * Compares ULID instance lexicographically.<br>
+   *
+   * If the two ULID instances share a common prefix, then the lexicographic comparison is the
+   * result of comparing the rest of the value of the two ULID instances.<br>
+   *
+   * A null ULID instance reference is considered lexicographically less than a non-null ULID
+   * instance reference.<br>
+   *
+   * Two null ULID instances references are considered equal.<br>
+   *
+   * The comparison is consistent with equals, where the ULID instances are equal if and only if
+   * they are lexicographically equal.
+   *
+   * @param obj the ULID instance to compare
+   * @return the value 0 if the ULID instance are equal and contain the same value; a value less
+   *         than 0 if this ULID instance is lexicographically less than the ULID instance; and a
+   *         value greater than 0 if this ULID instance is lexicographically greater than the ULID
+   *         instance
+   * @since 1.1.0
+   */
+  @Override
+  public int compareTo(ULID obj) {
+    return compare(this, obj);
+  }
+
+  /**
+   * Compares this object to the specified object. The result is true if and only if the argument is
+   * not null, is a ULID instance and has the same timestamp and entropy.
+   *
+   * @param obj the ULID instance to compare with
+   * @return true if the objects are the same; false otherwise
+   * @since 1.1.0
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if ((null == obj) || (obj.getClass() != ULID.class))
+      return false;
+    return Arrays.equals(this.binary, ((ULID) obj).binary);
+  }
+
+  /**
+   * Returns a hash code for this ULID instance.
+   *
+   * @return A hash code value for this ULID instance
+   * @since 1.1.0
+   */
+  @Override
+  public int hashCode() {
+    return 67 * Arrays.hashCode(this.binary);
+  }
+
+  /**
+   * Compares two ULID instances lexicographically.<br>
+   *
+   * If the two ULID instances share a common prefix, then the lexicographic comparison is the
+   * result of comparing the rest of the value of the two ULID instances.<br>
+   *
+   * A null ULID instance reference is considered lexicographically less than a non-null ULID
+   * instance reference.<br>
+   *
+   * The comparison is consistent with equals, where the ULID instances are equal if and only if
+   * they are lexicographically equal.
+   *
+   * @param a the first ULID instance to compare
+   * @param b the second ULID instance to compare
+   * @return the value 0 if the first and second ULID instance are equal and contain the same value;
+   *         a value less than 0 if the first ULID instance is lexicographically less than the
+   *         second ULID instance; and a value greater than 0 if the first ULID instance is
+   *         lexicographically greater than the second ULID instance
+   * @since 1.1.0
+   */
+  public static int compare(ULID a, ULID b) {
+    if (a == b)
+      return 0;
+    if (a == null || b == null)
+      return a == null ? -1 : 1;
+    // {@link Arrays.compareUnsigned(byte[], byte[])} is not available in Java 7
+    int len = Math.min(a.binary.length, b.binary.length);
+    for (int i = 0; i < len; i++) {
+      int aInt = a.binary[i] & 0xff;
+      int bInt = b.binary[i] & 0xff;
+      int cmp = Integer.compare(aInt, bInt);
+      if (cmp != 0)
+        return cmp;
+    }
+    return a.binary.length - b.binary.length;
+  }
+
+  /**
+   * Generate random ULID string using default {@link java.util.Random} instance backed by
+   * {@link java.security.SecureRandom}.
+   *
+   * @return ULID string
+   * @throws IllegalArgumentException if current time is out of ULID specification
+   * @since 0.0.1
    */
   public static String random() {
-    byte[] entropy = new byte[10];
-    Random random = new Random();
-    random.nextBytes(entropy);
+    byte[] entropy = new byte[ENTROPY_LENGTH];
+    LazyDefaults.random.nextBytes(entropy);
     return generate(System.currentTimeMillis(), entropy);
   }
 
   /**
-   * Generate random ULID binary using {@link java.util.Random} instance.
+   * Generate random ULID binary using default {@link java.util.Random} instance backed by
+   * {@link java.security.SecureRandom}.
    *
    * @return ULID binary
+   * @throws IllegalArgumentException if current time is out of ULID specification
+   * @since 1.0.4
    */
   public static byte[] randomBinary() {
-    byte[] entropy = new byte[10];
-    Random random = new Random();
-    random.nextBytes(entropy);
+    byte[] entropy = new byte[ENTROPY_LENGTH];
+    LazyDefaults.random.nextBytes(entropy);
     return generateBinary(System.currentTimeMillis(), entropy);
+  }
+
+  /**
+   * Generate random ULID instance using default {@link java.util.Random} instance backed by
+   * {@link java.security.SecureRandom}.
+   *
+   * @return ULID instance
+   * @throws IllegalArgumentException if current time is out of ULID specification
+   * @since 1.1.0
+   */
+  public static ULID randomULID() {
+    return new ULID(randomBinary());
   }
 
   /**
@@ -189,9 +433,11 @@ public class ULID {
    *
    * @param random {@link java.util.Random} instance
    * @return ULID string
+   * @throws IllegalArgumentException if current time is out of ULID specification
+   * @since 0.0.1
    */
   public static String random(Random random) {
-    byte[] entropy = new byte[10];
+    byte[] entropy = new byte[ENTROPY_LENGTH];
     random.nextBytes(entropy);
     return generate(System.currentTimeMillis(), entropy);
   }
@@ -201,29 +447,45 @@ public class ULID {
    *
    * @param random {@link java.util.Random} instance
    * @return ULID string
+   * @throws IllegalArgumentException if current time is out of ULID specification
+   * @since 1.0.4
    */
   public static byte[] randomBinary(Random random) {
-    byte[] entropy = new byte[10];
+    byte[] entropy = new byte[ENTROPY_LENGTH];
     random.nextBytes(entropy);
     return generateBinary(System.currentTimeMillis(), entropy);
   }
 
   /**
+   * Generate random ULID instance using provided {@link java.util.Random} instance.
+   *
+   * @param random {@link java.util.Random} instance
+   * @return ULID instance
+   * @throws IllegalArgumentException if current time is out of ULID specification
+   * @since 1.1.0
+   */
+  public static ULID randomULID(Random random) {
+    return new ULID(randomBinary(random));
+  }
+
+  /**
    * Generate ULID string from Unix epoch timestamp in millisecond and entropy bytes. Throws
    * {@link java.lang.IllegalArgumentException} if timestamp is less than {@value #MIN_TIME}, is
-   * more than {@value #MAX_TIME}, or entropy bytes is null or less than 10 bytes.
+   * more than {@value #MAX_TIME}, or entropy bytes is not 10 bytes.
    *
    * @param time Unix epoch timestamp in millisecond
    * @param entropy Entropy bytes
    * @return ULID string
+   * @throws IllegalArgumentException if time is out of ULID specification, or entropy is less than
+   *         10
+   * @since 0.0.1
    */
   public static String generate(long time, byte[] entropy) {
-    if (time < MIN_TIME || time > MAX_TIME || entropy == null || entropy.length < ENTROPY_LENGTH) {
+    if (time < MIN_TIME || time > MAX_TIME || entropy == null || entropy.length != ENTROPY_LENGTH)
       throw new IllegalArgumentException(
-          "Time is too long, or entropy is less than 10 bytes or null");
-    }
+          "Time is out of ULID specification, or entropy is less than 10 bytes or null");
 
-    char[] chars = new char[26];
+    char[] chars = new char[ULID_LENGTH];
 
     // time
     chars[0] = C[((byte) (time >>> 45)) & 0x1f];
@@ -261,19 +523,21 @@ public class ULID {
   /**
    * Generate ULID binary from Unix epoch timestamp in millisecond and entropy bytes. Throws
    * {@link java.lang.IllegalArgumentException} if timestamp is less than {@value #MIN_TIME}, is
-   * more than {@value #MAX_TIME}, or entropy bytes is null or less than 10 bytes.
+   * more than {@value #MAX_TIME}, or entropy bytes not 10 bytes.
    *
    * @param time Unix epoch timestamp in millisecond
    * @param entropy Entropy bytes
    * @return ULID string
+   * @throws IllegalArgumentException if time is out of ULID specification, or entropy is less than
+   *         10
+   * @since 1.0.4
    */
   public static byte[] generateBinary(long time, byte[] entropy) {
-    if (time < MIN_TIME || time > MAX_TIME || entropy == null || entropy.length < ENTROPY_LENGTH) {
+    if (time < MIN_TIME || time > MAX_TIME || entropy == null || entropy.length != ENTROPY_LENGTH)
       throw new IllegalArgumentException(
-          "Time is too long, or entropy is less than 10 bytes or null");
-    }
+          "Time is out of ULID specification, or entropy is less than 10 bytes or null");
 
-    byte[] bytes = new byte[ULID.ULID_BINARY_LENGTH];
+    byte[] bytes = new byte[ULID_BINARY_LENGTH];
 
     // Long to big endian byte array up to 6 bytes
     long ts = time;
@@ -289,19 +553,41 @@ public class ULID {
   }
 
   /**
+   * Generate ULID instance from Unix epoch timestamp in millisecond and entropy bytes. Throws
+   * {@link java.lang.IllegalArgumentException} if timestamp is less than {@value #MIN_TIME}, is
+   * more than {@value #MAX_TIME}, or entropy bytes is null or less than 10 bytes.
+   *
+   * @param time Unix epoch timestamp in millisecond
+   * @param entropy Entropy bytes
+   * @return ULID instance
+   * @throws IllegalArgumentException if time is out of ULID specification, or entropy is less than
+   *         10
+   * @since 1.1.0
+   */
+  public static ULID generateULID(long time, byte[] entropy) {
+    return new ULID(generateBinary(time, entropy));
+
+  }
+
+  /**
    * Checks ULID string validity.
    *
    * @param ulid ULID string
    * @return true if ULID string is valid
+   * @since 0.0.1
    */
   public static boolean isValid(CharSequence ulid) {
-    if (ulid == null || ulid.length() != ULID_LENGTH) {
+    if (ulid == null || ulid.length() != ULID_LENGTH)
       return false;
-    }
-    for (int i = 0; i < ULID_LENGTH; i++) {
-      /** We only care for chars between 0x00 and 0xff. */
+    // Maximum encodable timestamp is 50-bit, but ULID limits to 48-bit.
+    // {@link ULID.MAX_TIME}
+    char char0 = ulid.charAt(0);
+    if (char0 > V.length || V[char0] == (byte) 0xff || V[char0] > 0x07)
+      return false;
+    for (int i = 1; i < ULID_LENGTH; i++) {
+      // We only care for chars between 0x00 and 0xff.
       char c = ulid.charAt(i);
-      if (c < 0 || c > V.length || V[c] == (byte) 0xff) {
+      if (c > V.length || V[c] == (byte) 0xff) {
         return false;
       }
     }
@@ -313,20 +599,23 @@ public class ULID {
    *
    * @param ulid ULID binary
    * @return true if ULID binary is valid
+   * @since 1.0.4
    */
   public static boolean isValidBinary(byte[] ulid) {
     return ulid != null && ulid.length == ULID_BINARY_LENGTH;
   }
 
   /**
-   * Extract and return the timestamp part from ULID string. Expects a valid ULID string. Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
-   * if you do not trust the origin of the ULID string.
+   * Extract and return the timestamp part from ULID string. Expects a valid ULID string.
    *
    * @param ulid ULID string
    * @return Unix epoch timestamp in millisecond
+   * @throws IllegalArgumentException if the ULID string is not valid
+   * @since 0.0.1
    */
   public static long getTimestamp(CharSequence ulid) {
+    if (!isValid(ulid))
+      throw new IllegalArgumentException("Invalid ULID string");
     return (long) V[ulid.charAt(0)] << 45 //
         | (long) V[ulid.charAt(1)] << 40 //
         | (long) V[ulid.charAt(2)] << 35 //
@@ -340,15 +629,17 @@ public class ULID {
   }
 
   /**
-   * Extract and return the timestamp part from ULID binary. Expects a valid ULID binary. Call
-   * {@link io.azam.ulidj.ULID#isValidBinary(byte[])} and check validity before calling this method
-   * if you do not trust the origin of the ULID string.
+   * Extract and return the timestamp part from ULID binary.
    *
    * @param ulid ULID string
    * @return Unix epoch timestamp in millisecond
+   * @throws IllegalArgumentException if the ULID binary is not valid
+   * @since 1.0.4
    */
   public static long getTimestampBinary(byte[] ulid) {
-    long timestamp = (long) ulid[0];
+    if (!isValidBinary(ulid))
+      throw new IllegalArgumentException("Invalid ULID binary");
+    long timestamp = (long) ulid[0] & 0xff;
     timestamp = (timestamp << 8) | ulid[1] & 0xff;
     timestamp = (timestamp << 8) | ulid[2] & 0xff;
     timestamp = (timestamp << 8) | ulid[3] & 0xff;
@@ -358,14 +649,16 @@ public class ULID {
   }
 
   /**
-   * Extract and return the entropy part from ULID string. Expects a valid ULID string. Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
-   * if you do not trust the origin of the ULID string.
+   * Extract and return the entropy part from ULID string.
    *
    * @param ulid ULID string
    * @return Entropy bytes
+   * @throws IllegalArgumentException if the ULID string is not valid
+   * @since 0.0.1
    */
   public static byte[] getEntropy(CharSequence ulid) {
+    if (!isValid(ulid))
+      throw new IllegalArgumentException("Invalid ULID string");
     byte[] bytes = new byte[ENTROPY_LENGTH];
     bytes[0] = (byte) ((V[ulid.charAt(10)] << 3) //
         | (V[ulid.charAt(11)] & 0xff) >>> 2);
@@ -395,44 +688,32 @@ public class ULID {
   }
 
   /**
-   * Extract and return the entropy part from ULID binary. Expects a valid ULID binary. Call
-   * {@link io.azam.ulidj.ULID#isValidBinary(byte[])} and check validity before calling this method
-   * if you do not trust the origin of the ULID string.
+   * Extract and return the entropy part from ULID binary.
    *
    * @param ulid ULID binary
    * @return Entropy bytes
+   * @throws IllegalArgumentException if the ULID binary is not valid
+   * @since 1.0.4
    */
   public static byte[] getEntropyBinary(byte[] ulid) {
+    if (!isValidBinary(ulid))
+      throw new IllegalArgumentException("Invalid ULID binary");
     byte[] bytes = new byte[ENTROPY_LENGTH];
     System.arraycopy(ulid, 6, bytes, 0, 10);
     return bytes;
   }
 
   /**
-   * Convert a valid ULID string to it's binary representation. Call
-   * {@link io.azam.ulidj.ULID#isValid(CharSequence)} and check validity before calling this method
-   * if you do not trust the origin of the ULID string.<br>
-   * <br>
-   * Binary layout:
-   *
-   * <pre>
-   * 0                   1                   2                   3
-   *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |                      32_bit_uint_time_high                    |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |     16_bit_uint_time_low      |       16_bit_uint_random      |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |                       32_bit_uint_random                      |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |                       32_bit_uint_random                      |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * </pre>
+   * Convert a valid ULID string representation to its binary representation.
    *
    * @param ulid ULID string
    * @return ULID binary
+   * @throws IllegalArgumentException if the ULID string is not valid
+   * @since 1.0.4
    */
   public static byte[] toBinary(CharSequence ulid) {
+    if (!isValid(ulid))
+      throw new IllegalArgumentException("Invalid ULID string");
     byte[] bytes = new byte[ULID_BINARY_LENGTH];
     // Timestamp
     bytes[0] = (byte) ((V[ulid.charAt(0)] << 5) //
@@ -478,62 +759,74 @@ public class ULID {
   }
 
   /**
-   * Convert a valid ULID binary representation to it's string representation. Call
-   * {@link io.azam.ulidj.ULID#isValidBinary(byte[])} and check validity before calling this method
-   * if you do not trust the origin of the ULID string.<br>
-   * <br>
-   * Binary layout:
+   * Convert a valid ULID binary representation to its string representation.
    *
-   * <pre>
-   * 0                   1                   2                   3
-   *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |                      32_bit_uint_time_high                    |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |     16_bit_uint_time_low      |       16_bit_uint_random      |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |                       32_bit_uint_random                      |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * |                       32_bit_uint_random                      |
-   * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   * </pre>
-   *
-   * @param binary ULID binary
+   * @param ulid ULID binary
    * @return ULID string
+   * @throws IllegalArgumentException if the ULID binary is not valid
+   * @since 1.0.4
    */
-  public static String fromBinary(byte[] binary) {
-    char[] chars = new char[26];
+  public static String fromBinary(byte[] ulid) {
+    if (!isValidBinary(ulid))
+      throw new IllegalArgumentException("Invalid ULID binary");
+    char[] chars = new char[ULID_LENGTH];
 
     // time
-    chars[0] = C[(byte) (((binary[0] & 0xff) >>> 5) & 0x1f)];
-    chars[1] = C[(byte) (binary[0] & 0x1f)];
-    chars[2] = C[(byte) ((binary[1] & 0xff) >>> 3)];
-    chars[3] = C[(byte) (((binary[1] << 2) | ((binary[2] & 0xff) >>> 6)) & 0x1f)];
-    chars[4] = C[(byte) (((binary[2] & 0xff) >>> 1) & 0x1f)];
-    chars[5] = C[(byte) (((binary[2] << 4) | ((binary[3] & 0xff) >>> 4)) & 0x1f)];
-    chars[6] = C[(byte) (((binary[3] << 1) | ((binary[4] & 0xff) >>> 7)) & 0x1f)];
-    chars[7] = C[(byte) (((binary[4] & 0xff) >>> 2) & 0x1f)];
-    chars[8] = C[(byte) (((binary[4] << 3) | ((binary[5] & 0xff) >>> 5)) & 0x1f)];
-    chars[9] = C[(byte) (binary[5] & 0x1f)];
+    chars[0] = C[(byte) (((ulid[0] & 0xff) >>> 5) & 0x1f)];
+    chars[1] = C[(byte) (ulid[0] & 0x1f)];
+    chars[2] = C[(byte) ((ulid[1] & 0xff) >>> 3)];
+    chars[3] = C[(byte) (((ulid[1] << 2) | ((ulid[2] & 0xff) >>> 6)) & 0x1f)];
+    chars[4] = C[(byte) (((ulid[2] & 0xff) >>> 1) & 0x1f)];
+    chars[5] = C[(byte) (((ulid[2] << 4) | ((ulid[3] & 0xff) >>> 4)) & 0x1f)];
+    chars[6] = C[(byte) (((ulid[3] << 1) | ((ulid[4] & 0xff) >>> 7)) & 0x1f)];
+    chars[7] = C[(byte) (((ulid[4] & 0xff) >>> 2) & 0x1f)];
+    chars[8] = C[(byte) (((ulid[4] << 3) | ((ulid[5] & 0xff) >>> 5)) & 0x1f)];
+    chars[9] = C[(byte) (ulid[5] & 0x1f)];
 
     // entropy
-    chars[10] = C[(byte) ((binary[6] & 0xff) >>> 3)];
-    chars[11] = C[(byte) (((binary[6] << 2) | ((binary[7] & 0xff) >>> 6)) & 0x1f)];
-    chars[12] = C[(byte) (((binary[7] & 0xff) >>> 1) & 0x1f)];
-    chars[13] = C[(byte) (((binary[7] << 4) | ((binary[8] & 0xff) >>> 4)) & 0x1f)];
-    chars[14] = C[(byte) (((binary[8] << 1) | ((binary[9] & 0xff) >>> 7)) & 0x1f)];
-    chars[15] = C[(byte) (((binary[9] & 0xff) >>> 2) & 0x1f)];
-    chars[16] = C[(byte) (((binary[9] << 3) | ((binary[10] & 0xff) >>> 5)) & 0x1f)];
-    chars[17] = C[(byte) (binary[10] & 0x1f)];
-    chars[18] = C[(byte) ((binary[11] & 0xff) >>> 3)];
-    chars[19] = C[(byte) (((binary[11] << 2) | ((binary[12] & 0xff) >>> 6)) & 0x1f)];
-    chars[20] = C[(byte) (((binary[12] & 0xff) >>> 1) & 0x1f)];
-    chars[21] = C[(byte) (((binary[12] << 4) | ((binary[13] & 0xff) >>> 4)) & 0x1f)];
-    chars[22] = C[(byte) (((binary[13] << 1) | ((binary[14] & 0xff) >>> 7)) & 0x1f)];
-    chars[23] = C[(byte) (((binary[14] & 0xff) >>> 2) & 0x1f)];
-    chars[24] = C[(byte) (((binary[14] << 3) | ((binary[15] & 0xff) >>> 5)) & 0x1f)];
-    chars[25] = C[(byte) (binary[15] & 0x1f)];
+    chars[10] = C[(byte) ((ulid[6] & 0xff) >>> 3)];
+    chars[11] = C[(byte) (((ulid[6] << 2) | ((ulid[7] & 0xff) >>> 6)) & 0x1f)];
+    chars[12] = C[(byte) (((ulid[7] & 0xff) >>> 1) & 0x1f)];
+    chars[13] = C[(byte) (((ulid[7] << 4) | ((ulid[8] & 0xff) >>> 4)) & 0x1f)];
+    chars[14] = C[(byte) (((ulid[8] << 1) | ((ulid[9] & 0xff) >>> 7)) & 0x1f)];
+    chars[15] = C[(byte) (((ulid[9] & 0xff) >>> 2) & 0x1f)];
+    chars[16] = C[(byte) (((ulid[9] << 3) | ((ulid[10] & 0xff) >>> 5)) & 0x1f)];
+    chars[17] = C[(byte) (ulid[10] & 0x1f)];
+    chars[18] = C[(byte) ((ulid[11] & 0xff) >>> 3)];
+    chars[19] = C[(byte) (((ulid[11] << 2) | ((ulid[12] & 0xff) >>> 6)) & 0x1f)];
+    chars[20] = C[(byte) (((ulid[12] & 0xff) >>> 1) & 0x1f)];
+    chars[21] = C[(byte) (((ulid[12] << 4) | ((ulid[13] & 0xff) >>> 4)) & 0x1f)];
+    chars[22] = C[(byte) (((ulid[13] << 1) | ((ulid[14] & 0xff) >>> 7)) & 0x1f)];
+    chars[23] = C[(byte) (((ulid[14] & 0xff) >>> 2) & 0x1f)];
+    chars[24] = C[(byte) (((ulid[14] << 3) | ((ulid[15] & 0xff) >>> 5)) & 0x1f)];
+    chars[25] = C[(byte) (ulid[15] & 0x1f)];
 
     return new String(chars);
+  }
+
+  /**
+   * Constructs an immutable ULID instance using provided ULID string.
+   *
+   * @param ulid ULID string
+   * @return ULID instance
+   * @throws IllegalArgumentException if the ULID string is not valid
+   * @since 1.1.0
+   */
+  public static ULID parseULID(CharSequence ulid) {
+    return new ULID(toBinary(ulid));
+  }
+
+  /**
+   * Constructs an immutable ULID instance using provided ULID binary byte array.
+   *
+   * @param ulid ULID binary
+   * @return ULID instance
+   * @throws IllegalArgumentException if the ULID binary byte array is not valid
+   * @since 1.1.0
+   */
+  public static ULID parseULID(byte[] ulid) {
+    if (isValidBinary(ulid))
+      return new ULID(ulid);
+    throw new IllegalArgumentException("Invalid ULID binary");
   }
 }

--- a/src/main/java/io/azam/ulidj/ULID.java
+++ b/src/main/java/io/azam/ulidj/ULID.java
@@ -26,45 +26,89 @@ import java.util.Arrays;
 import java.util.Random;
 
 /**
- * ULID string generator and parser class, using Crockford Base32 encoding. Only upper case letters
- * are used for generation. Parsing allows upper and lower case letters, and i and l will be treated
- * as 1 and o will be treated as 0. <br>
+ * ULID implementation in Java. This class implements an immutable, sortable (implements
+ * {@link java.lang.Comparable}) ULID instance, convertors and helper methods for ULID string,
+ * binary representations.<br>
+ * <br>
+ * ULID string representations are generated as upper case letters. Parsing of ULID strings allow
+ * upper and lower case letters, where `i` and `l` will be treated as `1` and `o` will be treated as
+ * `0`. <br>
+ * <br>
  *
- * ULID immutable sortable (implements {@link java.lang.Comparable}) valid instance generation. <br>
+ * ULID instance generation examples:<br>
  *
  * <pre>
+ * // Using default Random instance backed by SecureRandom
  * ULID ulid1 = ULID.randomULID();
+ * // Using provided Random instance
  * ULID ulid2 = ULID.randomULID(ThreadLocalRandom.current());
+ * // Using provided SecureRandom instance
  * ULID ulid3 = ULID.parseULID("003JZ9J6G80123456789abcdef");
- * ULID ulid4 = ULID.parseULID(
+ * // Convert ULID string to ULID instance
+ * ULID ulid4 = ULID.parseULID("003JZ9J6G80123456789abcdef");
+ * // Convert ULID binary to ULID instance
+ * ULID ulid5 = ULID.parseULID(
  *     new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf});
- * ULID ulid5 = ULID.generateULID(System.currentTimeMillis(), entropy);
+ * // Instantiate a ULID instance from current time and provided entropy bytes
+ * ULID ulid6 = ULID.generateULID(System.currentTimeMillis(), entropy);
+ * // Sort ULID instances lexicographically
+ * List&lt;ULID&gt; ulids = Arrays.asList(ulid1, ulid2, ulid3, ulid4, ulid5, ulid6);
+ * Collections.sort(ulids);
  * </pre>
  *
  * ULID string generation examples:<br>
  *
  * <pre>
+ * // Using default Random instance backed by SecureRandom
  * String ulid1 = ULID.random();
+ * // Using provided Random instance
  * String ulid2 = ULID.random(ThreadLocalRandom.current());
+ * // Using provided SecureRandom instance
  * String ulid3 = ULID.random(SecureRandom.newInstance("SHA1PRNG"));
+ * // Generate ULID string from current time and provided entropy bytes
  * byte[] entropy = new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
  * String ulid4 = ULID.generate(System.currentTimeMillis(), entropy);
+ * // Convert ULID binary to ULID string
+ * String ulid5 = ULID.fromBinary(
+ *     new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf});
  * </pre>
  *
- * ULID parsing examples:<br>
+ * ULID binary generation examples:<br>
+ *
+ * <pre>
+ * // Using default Random instance backed by SecureRandom
+ * byte[] ulid1 = ULID.randomBinary();
+ * // Using provided Random instance
+ * byte[] ulid2 = ULID.randomBinary(ThreadLocalRandom.current());
+ * // Using provided SecureRandom instance
+ * byte[] ulid3 = ULID.randomBinary(SecureRandom.newInstance("SHA1PRNG"));
+ * // Generate ULID string from current time and provided entropy bytes
+ * byte[] entropy = new byte[] {0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
+ * byte[] ulid4 = ULID.generateBinary(System.currentTimeMillis(), entropy);
+ * // Convert ULID string to ULID binary
+ * byte[] ulid5 = ULID.toBinary("003JZ9J6G80123456789abcdef");
+ * </pre>
+ *
+ * ULID utilities:<br>
  *
  * <pre>
  * String ulid = "003JZ9J6G80123456789abcdef";
+ * // Validate ULID string
  * assert ULID.isValid(ulid);
+ * // Get timestamp from ULID string
  * long ts = ULID.getTimestamp(ulid);
  * assert ts == 123456789000L;
+ * // Get entropy from ULID string
  * byte[] entropy = ULID.getEntropy(ulid);
  *
  * byte[] ulidBinary =
  *     new byte[] {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0xf, 0xf, 0xf, 0xf, 0xf, 0xf};
+ * // Validate ULID binary
  * assert ULID.isValidBinary(ulidBinary);
+ * // Get timestamp from ULID binary
  * long tsBinary = ULID.getTimestampBinary(ulidBinary);
  * assert tsBinary == 1L;
+ * // Get entropy from ULID binary
  * byte[] entropyBinary = ULID.getEntropyBinary(ulidBinary);
  * </pre>
  *
@@ -292,15 +336,15 @@ public final class ULID implements Serializable, Comparable<ULID> {
 
   /**
    * Compares ULID instance lexicographically.<br>
-   *
+   * <br>
    * If the two ULID instances share a common prefix, then the lexicographic comparison is the
    * result of comparing the rest of the value of the two ULID instances.<br>
-   *
+   * <br>
    * A null ULID instance reference is considered lexicographically less than a non-null ULID
    * instance reference.<br>
-   *
+   * <br>
    * Two null ULID instances references are considered equal.<br>
-   *
+   * <br>
    * The comparison is consistent with equals, where the ULID instances are equal if and only if
    * they are lexicographically equal.
    *
@@ -344,13 +388,13 @@ public final class ULID implements Serializable, Comparable<ULID> {
 
   /**
    * Compares two ULID instances lexicographically.<br>
-   *
+   * <br>
    * If the two ULID instances share a common prefix, then the lexicographic comparison is the
    * result of comparing the rest of the value of the two ULID instances.<br>
-   *
+   * <br>
    * A null ULID instance reference is considered lexicographically less than a non-null ULID
    * instance reference.<br>
-   *
+   * <br>
    * The comparison is consistent with equals, where the ULID instances are equal if and only if
    * they are lexicographically equal.
    *

--- a/src/main/java/io/azam/ulidj/ULID.java
+++ b/src/main/java/io/azam/ulidj/ULID.java
@@ -239,15 +239,6 @@ public final class ULID implements Serializable, Comparable<ULID> {
   private final byte[] binary;
 
   /**
-   * ULID no argument constructor is private to prevent instantiation and finalizing attacks.
-   *
-   * @since 1.1.0
-   */
-  private ULID() {
-    throw new UnsupportedOperationException("Use randomULID() or randomBinary() to generate ULID");
-  }
-
-  /**
    * Constructs an immutable ULID instance using provided ULID binary byte array.
    *
    * @param value ULID binary

--- a/src/test/java/io/azam/ulidj/FixedRandom.java
+++ b/src/test/java/io/azam/ulidj/FixedRandom.java
@@ -1,7 +1,7 @@
-/**
+/*
  * MIT License
  *
- * Copyright (c) 2016 Azamshul Azizy
+ * Copyright (c) 2016-2025 Azamshul Azizy
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/test/java/io/azam/ulidj/MonotonicULIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDBenchmark.java
@@ -1,4 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2025 Azamshul Azizy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package io.azam.ulidj;
+
+import java.security.SecureRandom;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
@@ -10,16 +34,77 @@ import org.openjdk.jmh.infra.Blackhole;
 public class MonotonicULIDBenchmark {
   @State(Scope.Thread)
   public static class MonotonicULIDState {
-    public MonotonicULID instance;
+    public MonotonicULID noArgs;
+    public MonotonicULID random;
+    public MonotonicULID secureRandom;
+    public MonotonicULID threadLocalRandom;
 
     @Setup(Level.Trial)
     public void doSetup() {
-      instance = new MonotonicULID();
+      this.noArgs = new MonotonicULID();
+      this.random = new MonotonicULID(new Random());
+      this.secureRandom = new MonotonicULID(new SecureRandom());
+      this.threadLocalRandom = new MonotonicULID(ThreadLocalRandom.current());
     }
   }
 
   @Benchmark
-  public void generate(Blackhole blackhole, MonotonicULIDState state) {
-    blackhole.consume(state.instance.generate());
+  public void generateNoArgs(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.noArgs.generate());
+  }
+
+  @Benchmark
+  public void generateBinaryNoArgs(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.noArgs.generateBinary());
+  }
+
+  @Benchmark
+  public void generateULIDNoArgs(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.noArgs.generateULID());
+  }
+
+  @Benchmark
+  public void generateRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.random.generate());
+  }
+
+  @Benchmark
+  public void generateBinaryRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.random.generateBinary());
+  }
+
+  @Benchmark
+  public void generateULIDRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.random.generateULID());
+  }
+
+  @Benchmark
+  public void generateSecureRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.secureRandom.generate());
+  }
+
+  @Benchmark
+  public void generateBinarySecureRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.secureRandom.generateBinary());
+  }
+
+  @Benchmark
+  public void generateULIDSecureRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.secureRandom.generateULID());
+  }
+
+  @Benchmark
+  public void generateThreadLocalRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.threadLocalRandom.generate());
+  }
+
+  @Benchmark
+  public void generateBinaryThreadLocalRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.threadLocalRandom.generateBinary());
+  }
+
+  @Benchmark
+  public void generateULIDThreadLocalRandom(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.threadLocalRandom.generateULID());
   }
 }

--- a/src/test/java/io/azam/ulidj/MonotonicULIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDBenchmark.java
@@ -107,4 +107,19 @@ public class MonotonicULIDBenchmark {
   public void generateULIDThreadLocalRandom(Blackhole blackhole, MonotonicULIDState state) {
     blackhole.consume(state.threadLocalRandom.generateULID());
   }
+
+  @Benchmark
+  public void random(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(MonotonicULID.random());
+  }
+
+  @Benchmark
+  public void randomBinary(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(MonotonicULID.randomBinary());
+  }
+
+  @Benchmark
+  public void randomULID(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(MonotonicULID.randomULID());
+  }
 }

--- a/src/test/java/io/azam/ulidj/MonotonicULIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDBenchmark.java
@@ -1,0 +1,25 @@
+package io.azam.ulidj;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class MonotonicULIDBenchmark {
+  @State(Scope.Thread)
+  public static class MonotonicULIDState {
+    public MonotonicULID instance;
+
+    @Setup(Level.Trial)
+    public void doSetup() {
+      instance = new MonotonicULID();
+    }
+  }
+
+  @Benchmark
+  public void generate(Blackhole blackhole, MonotonicULIDState state) {
+    blackhole.consume(state.instance.generate());
+  }
+}

--- a/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
@@ -29,21 +29,15 @@ import java.util.Random;
 
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static io.azam.ulidj.TestUtils.incrementBytes;
 import static io.azam.ulidj.ULIDTest.FILLED_ENTROPY;
 import static io.azam.ulidj.ULIDTest.TEST_RANDOM;
-import static io.azam.ulidj.ULIDTest.TEST_TIMESTAMP;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Test class for {@link io.azam.ulidj.MonotonicULID}
@@ -51,8 +45,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
  * @author azam
  * @since 1.0.3
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({System.class, MonotonicULID.class})
 public class MonotonicULIDTest {
   @Test
   public void testConstructor() {
@@ -72,79 +64,11 @@ public class MonotonicULIDTest {
   }
 
   @Test
-  public void testGenerateNegativeMock() {
-    mockStatic(System.class);
-    when(System.currentTimeMillis()).thenReturn(ULID.MIN_TIME - 1);
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            MonotonicULID ulid = new MonotonicULID();
-            String value = ulid.generate();
-          }
-        });
-    when(System.currentTimeMillis()).thenReturn(ULID.MAX_TIME + 1);
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            MonotonicULID ulid = new MonotonicULID();
-            String value = ulid.generate();
-          }
-        });
-    when(System.currentTimeMillis()).thenReturn(TEST_TIMESTAMP);
-    final MonotonicULID ulidEntropyOverflow = new MonotonicULID(new FixedRandom(FILLED_ENTROPY));
-    String valid = ulidEntropyOverflow.generate();
-    assertTrue(ULID.isValid(valid));
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            String value = ulidEntropyOverflow.generate();
-          }
-        });
-  }
-
-  @Test
   public void testGenerateBinary() {
     MonotonicULID ulid = new MonotonicULID();
     byte[] value = ulid.generateBinary();
     assertNotNull(value);
     assertTrue(ULID.isValidBinary(value));
-  }
-
-  @Test
-  public void testGenerateBinaryNegativeMock() {
-    mockStatic(System.class);
-    when(System.currentTimeMillis()).thenReturn(ULID.MIN_TIME - 1);
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            MonotonicULID ulid = new MonotonicULID();
-            byte[] value = ulid.generateBinary();
-          }
-        });
-    when(System.currentTimeMillis()).thenReturn(ULID.MAX_TIME + 1);
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            MonotonicULID ulid = new MonotonicULID();
-            byte[] value = ulid.generateBinary();
-          }
-        });
-    when(System.currentTimeMillis()).thenReturn(TEST_TIMESTAMP);
-    final MonotonicULID ulidEntropyOverflow = new MonotonicULID(new FixedRandom(FILLED_ENTROPY));
-    String valid = ulidEntropyOverflow.generate();
-    assertTrue(ULID.isValid(valid));
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            byte[] value = ulidEntropyOverflow.generateBinary();
-          }
-        });
   }
 
   @Test
@@ -157,40 +81,6 @@ public class MonotonicULIDTest {
     assertTrue("ULID instance string value must be valid", ULID.isValid(value.toString()));
     assertNotNull("ULID instance binary value should not be null", value.toBinary());
     assertTrue("ULID instance binary value must be valid", ULID.isValidBinary(value.toBinary()));
-  }
-
-  @Test
-  public void testGenerateULIDNegativeMock() {
-    mockStatic(System.class);
-    when(System.currentTimeMillis()).thenReturn(ULID.MIN_TIME - 1);
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            MonotonicULID ulid = new MonotonicULID();
-            ULID value = ulid.generateULID();
-          }
-        });
-    when(System.currentTimeMillis()).thenReturn(ULID.MAX_TIME + 1);
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            MonotonicULID ulid = new MonotonicULID();
-            ULID value = ulid.generateULID();
-          }
-        });
-    when(System.currentTimeMillis()).thenReturn(TEST_TIMESTAMP);
-    final MonotonicULID ulidEntropyOverflow = new MonotonicULID(new FixedRandom(FILLED_ENTROPY));
-    String valid = ulidEntropyOverflow.generate();
-    assertTrue(ULID.isValid(valid));
-    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            ULID value = ulidEntropyOverflow.generateULID();
-          }
-        });
   }
 
   @Test

--- a/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
@@ -232,4 +232,26 @@ public class MonotonicULIDTest {
       }
     });
   }
+
+  @Test
+  public void testRandom() {
+    String value = MonotonicULID.random();
+    assertNotNull(value);
+    assertTrue(ULID.isValid(value));
+  }
+
+  @Test
+  public void testRandomBinary() {
+    byte[] value = MonotonicULID.randomBinary();
+    assertNotNull(value);
+    assertTrue(ULID.isValidBinary(value));
+  }
+
+  @Test
+  public void testRandomULID() {
+    ULID value = MonotonicULID.randomULID();
+    assertNotNull(value);
+    assertTrue(ULID.isValid(value.toString()));
+    assertTrue(ULID.isValidBinary(value.toBinary()));
+  }
 }

--- a/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
+++ b/src/test/java/io/azam/ulidj/MonotonicULIDTest.java
@@ -27,8 +27,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static io.azam.ulidj.TestUtils.incrementBytes;
+import static io.azam.ulidj.ULIDTest.FILLED_ENTROPY;
+import static io.azam.ulidj.ULIDTest.TEST_RANDOM;
+import static io.azam.ulidj.ULIDTest.TEST_TIMESTAMP;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Test class for {@link io.azam.ulidj.MonotonicULID}
@@ -36,37 +51,170 @@ import org.junit.Test;
  * @author azam
  * @since 1.0.3
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({System.class, MonotonicULID.class})
 public class MonotonicULIDTest {
   @Test
   public void testConstructor() {
-    Assert.assertNotNull(new MonotonicULID());
-    Assert.assertNotNull(new MonotonicULID(new Random()));
-    Assert.assertNotNull(new MonotonicULID(new SecureRandom()));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstructorNullRandom() {
-    new MonotonicULID(null);
+    assertNotNull(new MonotonicULID());
+    assertNotNull(new MonotonicULID(new Random()));
+    assertNotNull(new MonotonicULID(new SecureRandom()));
+    Random nullRandom = null;
+    assertNotNull(new MonotonicULID(nullRandom));
   }
 
   @Test
   public void testGenerate() {
     MonotonicULID ulid = new MonotonicULID();
     String value = ulid.generate();
-    Assert.assertNotNull(value);
-    Assert.assertTrue(ULID.isValid(value));
+    assertNotNull(value);
+    assertTrue(ULID.isValid(value));
+  }
+
+  @Test
+  public void testGenerateNegativeMock() {
+    mockStatic(System.class);
+    when(System.currentTimeMillis()).thenReturn(ULID.MIN_TIME - 1);
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            MonotonicULID ulid = new MonotonicULID();
+            String value = ulid.generate();
+          }
+        });
+    when(System.currentTimeMillis()).thenReturn(ULID.MAX_TIME + 1);
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            MonotonicULID ulid = new MonotonicULID();
+            String value = ulid.generate();
+          }
+        });
+    when(System.currentTimeMillis()).thenReturn(TEST_TIMESTAMP);
+    final MonotonicULID ulidEntropyOverflow = new MonotonicULID(new FixedRandom(FILLED_ENTROPY));
+    String valid = ulidEntropyOverflow.generate();
+    assertTrue(ULID.isValid(valid));
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            String value = ulidEntropyOverflow.generate();
+          }
+        });
   }
 
   @Test
   public void testGenerateBinary() {
     MonotonicULID ulid = new MonotonicULID();
     byte[] value = ulid.generateBinary();
-    Assert.assertNotNull(value);
-    Assert.assertTrue(ULID.isValidBinary(value));
+    assertNotNull(value);
+    assertTrue(ULID.isValidBinary(value));
   }
 
   @Test
-  public void testGenerateConcurrent() {
+  public void testGenerateBinaryNegativeMock() {
+    mockStatic(System.class);
+    when(System.currentTimeMillis()).thenReturn(ULID.MIN_TIME - 1);
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            MonotonicULID ulid = new MonotonicULID();
+            byte[] value = ulid.generateBinary();
+          }
+        });
+    when(System.currentTimeMillis()).thenReturn(ULID.MAX_TIME + 1);
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            MonotonicULID ulid = new MonotonicULID();
+            byte[] value = ulid.generateBinary();
+          }
+        });
+    when(System.currentTimeMillis()).thenReturn(TEST_TIMESTAMP);
+    final MonotonicULID ulidEntropyOverflow = new MonotonicULID(new FixedRandom(FILLED_ENTROPY));
+    String valid = ulidEntropyOverflow.generate();
+    assertTrue(ULID.isValid(valid));
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            byte[] value = ulidEntropyOverflow.generateBinary();
+          }
+        });
+  }
+
+  @Test
+  public void testGenerateULID() {
+    MonotonicULID ulid = new MonotonicULID();
+    ULID value = ulid.generateULID();
+    assertNotNull(value);
+    assertEquals(ULID.class, value.getClass());
+    assertNotNull("ULID instance string value should not be null", value.toString());
+    assertTrue("ULID instance string value must be valid", ULID.isValid(value.toString()));
+    assertNotNull("ULID instance binary value should not be null", value.toBinary());
+    assertTrue("ULID instance binary value must be valid", ULID.isValidBinary(value.toBinary()));
+  }
+
+  @Test
+  public void testGenerateULIDNegativeMock() {
+    mockStatic(System.class);
+    when(System.currentTimeMillis()).thenReturn(ULID.MIN_TIME - 1);
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            MonotonicULID ulid = new MonotonicULID();
+            ULID value = ulid.generateULID();
+          }
+        });
+    when(System.currentTimeMillis()).thenReturn(ULID.MAX_TIME + 1);
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            MonotonicULID ulid = new MonotonicULID();
+            ULID value = ulid.generateULID();
+          }
+        });
+    when(System.currentTimeMillis()).thenReturn(TEST_TIMESTAMP);
+    final MonotonicULID ulidEntropyOverflow = new MonotonicULID(new FixedRandom(FILLED_ENTROPY));
+    String valid = ulidEntropyOverflow.generate();
+    assertTrue(ULID.isValid(valid));
+    assertThrows("ULID timestamp is out of ULID specification", IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            ULID value = ulidEntropyOverflow.generateULID();
+          }
+        });
+  }
+
+  @Test
+  public void testGenerateExternalRandom() {
+    MonotonicULID ulid = new MonotonicULID(TEST_RANDOM);
+    String value = ulid.generate();
+    assertNotNull("ULID value should not be null", value);
+    assertTrue("ULID value must be valid", ULID.isValid(value));
+    assertArrayEquals("ULID entropy should be filled with the provided random", FILLED_ENTROPY,
+        ULID.getEntropy(value));
+  }
+
+  @Test
+  public void testGenerateBinaryExternalRandom() {
+    MonotonicULID ulid = new MonotonicULID(TEST_RANDOM);
+    byte[] value = ulid.generateBinary();
+    assertNotNull("Binary ULID value should not be null", value);
+    assertTrue("Binary ULID value must be valid", ULID.isValidBinary(value));
+    assertArrayEquals("Binary ULID entropy should be filled with the provided random",
+        FILLED_ENTROPY, ULID.getEntropyBinary(value));
+  }
+
+  @Test
+  public void testGenerateConcurrentNonDeterministic() {
     MonotonicULID ulid = new MonotonicULID();
     boolean hasSameTimestamp = false;
     // This test might not end if we cannot generate multiple ULID in the same
@@ -81,8 +229,8 @@ public class MonotonicULIDTest {
       // Group into timestamp bucket
       Map<Long, List<byte[]>> groups = new HashMap<Long, List<byte[]>>();
       for (String value : values) {
-        Assert.assertNotNull(value);
-        Assert.assertTrue(ULID.isValid(value));
+        assertNotNull(value);
+        assertTrue(ULID.isValid(value));
         long ts = ULID.getTimestamp(value);
         byte[] entropy = ULID.getEntropy(value);
         if (!groups.containsKey(ts)) {
@@ -103,7 +251,7 @@ public class MonotonicULIDTest {
             byte[] curr = bucketValues.get(i);
             // The next value on the same timestamp is an increment of 1-bit if the previous
             // value
-            Assert.assertArrayEquals(TestUtils.incrementBytes(prev), curr);
+            assertArrayEquals(incrementBytes(prev), curr);
             prev = curr;
           }
         }
@@ -112,7 +260,7 @@ public class MonotonicULIDTest {
   }
 
   @Test
-  public void testGenerateBinaryConcurrent() {
+  public void testGenerateBinaryConcurrentNonDeterministic() {
     MonotonicULID ulid = new MonotonicULID();
     boolean hasSameTimestamp = false;
     // This test might not end if we cannot generate multiple ULID in the same
@@ -127,8 +275,8 @@ public class MonotonicULIDTest {
       // Group into timestamp bucket
       Map<Long, List<byte[]>> groups = new HashMap<Long, List<byte[]>>();
       for (byte[] value : values) {
-        Assert.assertNotNull(value);
-        Assert.assertTrue(ULID.isValidBinary(value));
+        assertNotNull(value);
+        assertTrue(ULID.isValidBinary(value));
         long ts = ULID.getTimestampBinary(value);
         byte[] entropy = ULID.getEntropyBinary(value);
         if (!groups.containsKey(ts)) {
@@ -149,7 +297,7 @@ public class MonotonicULIDTest {
             byte[] curr = bucketValues.get(i);
             // The next value on the same timestamp is an increment of 1-bit if the previous
             // value
-            Assert.assertArrayEquals(TestUtils.incrementBytes(prev), curr);
+            assertArrayEquals(incrementBytes(prev), curr);
             prev = curr;
           }
         }
@@ -157,32 +305,41 @@ public class MonotonicULIDTest {
     }
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void testGenerateOverflow() {
+  @Test
+  public void testGenerateOverflowNonDeterministic() {
     // Using a random generator that always return 0xff... so that next increment on
     // the same timestamp will throw exception
-    MonotonicULID ulid = new MonotonicULID(new FixedRandom(new byte[] { //
+    final MonotonicULID ulid = new MonotonicULID(new FixedRandom(new byte[] { //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
     }));
-    List<String> values = new ArrayList<String>();
-    for (int i = 0; i < 1000000; i++) {
-      values.add(ulid.generate());
-    }
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() {
+        List<String> values = new ArrayList<String>();
+        for (int i = 0; i < 1000000; i++) {
+          values.add(ulid.generate());
+        }
+      }
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void testGenerateBinaryOverflow() {
+  @Test
+  public void testGenerateBinaryOverflowNonDeterministic() {
     // Using a random generator that always return 0xff... so that next increment on
     // the same timestamp will throw exception
-    MonotonicULID ulid = new MonotonicULID(new FixedRandom(new byte[] { //
+    final MonotonicULID ulid = new MonotonicULID(new FixedRandom(new byte[] { //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
     }));
-    List<byte[]> values = new ArrayList<byte[]>();
-    for (int i = 0; i < 1000000; i++) {
-      values.add(ulid.generateBinary());
-    }
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() {
+        List<byte[]> values = new ArrayList<byte[]>();
+        for (int i = 0; i < 1000000; i++) {
+          values.add(ulid.generateBinary());
+        }
+      }
+    });
   }
-
 }

--- a/src/test/java/io/azam/ulidj/TestUtils.java
+++ b/src/test/java/io/azam/ulidj/TestUtils.java
@@ -20,41 +20,44 @@
  */
 package io.azam.ulidj;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestUtils {
   @Test
   public void testIncrementBytes() {
-    Assert.assertArrayEquals(new byte[] { //
+    assertArrayEquals(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01 //
     }, incrementBytes(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 //
     }));
-    Assert.assertArrayEquals(new byte[] { //
+    assertArrayEquals(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
     }, incrementBytes(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xfe //
     }));
-    Assert.assertArrayEquals(new byte[] { //
+    assertArrayEquals(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00 //
     }, incrementBytes(new byte[] { //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, //
         (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff //
     }));
-    Assert.assertArrayEquals(new byte[] { //
+    assertArrayEquals(new byte[] { //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
     }, incrementBytes(new byte[] { //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xfe //
     }));
-    Assert.assertArrayEquals(null, incrementBytes(new byte[] { //
+    assertArrayEquals(null, incrementBytes(new byte[] { //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
     }));
@@ -80,5 +83,63 @@ public class TestUtils {
     }
 
     return value;
+  }
+
+  public static String bytesToInitializer(byte[] bytes) {
+    if (bytes == null)
+      return "null";
+    StringBuilder sb = new StringBuilder();
+    sb.append("new byte[] {");
+    for (int i = 0; i < bytes.length; i++) {
+      sb.append(String.format("(byte) 0x%02x", bytes[i]));
+      if (i < bytes.length - 1)
+        sb.append(",");
+    }
+    sb.append(" }");
+    return sb.toString();
+  }
+
+  /**
+   * Base32 characters mapping
+   */
+  private static final char[] C = new char[] { //
+      0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, //
+      0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, //
+      0x47, 0x48, 0x4a, 0x4b, 0x4d, 0x4e, 0x50, 0x51, //
+      0x52, 0x53, 0x54, 0x56, 0x57, 0x58, 0x59, 0x5a //
+  };
+
+  public static void assertEntropyIsIncremented(String prev, String next) {
+    assertEquals(prev.length(), next.length());
+    boolean charMustBeSame = false;
+    for (int i = next.length() - 1; i >= 0; i--) {
+      if (!charMustBeSame) {
+        // We assume only ASCII characters, so charAt is good enough here.
+        int nextCharIndex = indexOfElement(C, next.charAt(i));
+        int prevCharIndex = indexOfElement(C, prev.charAt(i));
+        assertTrue("Next ULID value contains invalid character", nextCharIndex >= 0);
+        assertEquals("Next base64 char is wrong", ((nextCharIndex + C.length - 1) % C.length),
+            prevCharIndex);
+        charMustBeSame = nextCharIndex < C.length && nextCharIndex > 0;
+      } else {
+        assertEquals(next.charAt(i), prev.charAt(i));
+      }
+    }
+  }
+
+  public static void assertEntropyIsIncremented(byte[] prev, byte[] next) {
+    assertEquals(prev.length, next.length);
+    assertArrayEquals(TestUtils.incrementBytes(ULID.getEntropyBinary(prev)),
+        ULID.getEntropyBinary(next));
+  }
+
+  public static int indexOfElement(char[] arr, char e) {
+    if (arr != null && arr.length > 0) {
+      for (int i = 0; i < arr.length; i++) {
+        if (arr[i] == e)
+          return i;
+      }
+    }
+    return -1;
   }
 }

--- a/src/test/java/io/azam/ulidj/ULIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/ULIDBenchmark.java
@@ -1,0 +1,30 @@
+package io.azam.ulidj;
+
+import java.security.SecureRandom;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class ULIDBenchmark {
+  private static final String TEST_VALUE = "00A9G895B0ZZZZZZZZZZZZZZZZ";
+
+  @Benchmark
+  public void random(Blackhole blackhole) {
+    blackhole.consume(ULID.random());
+  }
+
+  @Benchmark
+  public void secureRandom(Blackhole blackhole) {
+    blackhole.consume(ULID.random(new SecureRandom()));
+  }
+
+  @Benchmark
+  public void getTimestamp(Blackhole blackhole) {
+    blackhole.consume(ULID.getTimestamp(TEST_VALUE));
+  }
+
+  @Benchmark
+  public void getEntropy(Blackhole blackhole) {
+    blackhole.consume(ULID.getEntropy(TEST_VALUE));
+  }
+}

--- a/src/test/java/io/azam/ulidj/ULIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/ULIDBenchmark.java
@@ -1,21 +1,112 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2025 Azamshul Azizy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package io.azam.ulidj;
 
 import java.security.SecureRandom;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
 public class ULIDBenchmark {
   private static final String TEST_VALUE = "00A9G895B0ZZZZZZZZZZZZZZZZ";
+  private static final byte[] TEST_BINARY = new byte[] { //
+      (byte) 0x00, (byte) 0x52, (byte) 0x60, (byte) 0x84, //
+      (byte) 0x95, (byte) 0x60, (byte) 0xff, (byte) 0xff, //
+      (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, //
+      (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff //
+  };
+
+  @State(Scope.Thread)
+  public static class ULIDState {
+    public Random random;
+    public SecureRandom secureRandom;
+    public ThreadLocalRandom threadLocalRandom;
+
+    @Setup(Level.Trial)
+    public void doSetup() {
+      this.random = new Random();
+      this.secureRandom = new SecureRandom();
+      this.threadLocalRandom = ThreadLocalRandom.current();
+    }
+  }
 
   @Benchmark
-  public void random(Blackhole blackhole) {
+  public void random(Blackhole blackhole, ULIDState state) {
     blackhole.consume(ULID.random());
   }
 
   @Benchmark
-  public void secureRandom(Blackhole blackhole) {
-    blackhole.consume(ULID.random(new SecureRandom()));
+  public void randomBinary(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomBinary());
+  }
+
+  @Benchmark
+  public void randomULID(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomULID());
+  }
+
+  @Benchmark
+  public void randomWithRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.random(state.random));
+  }
+
+  @Benchmark
+  public void randomBinaryWithRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomBinary(state.random));
+  }
+
+  @Benchmark
+  public void randomWithSecureRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.random(state.secureRandom));
+  }
+
+  @Benchmark
+  public void randomBinaryWithSecureRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomBinary(state.secureRandom));
+  }
+
+  @Benchmark
+  public void randomULIDWithSecureRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomULID(state.secureRandom));
+  }
+
+  @Benchmark
+  public void randomWithThreadLocalRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.random(state.threadLocalRandom));
+  }
+
+  @Benchmark
+  public void randomBinaryWithThreadLocalRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomBinary(state.threadLocalRandom));
+  }
+
+  @Benchmark
+  public void randomULIDWithThreadLocalRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ULID.randomULID(state.threadLocalRandom));
   }
 
   @Benchmark
@@ -24,7 +115,42 @@ public class ULIDBenchmark {
   }
 
   @Benchmark
+  public void getTimestampBinary(Blackhole blackhole) {
+    blackhole.consume(ULID.getTimestampBinary(TEST_BINARY));
+  }
+
+  @Benchmark
   public void getEntropy(Blackhole blackhole) {
     blackhole.consume(ULID.getEntropy(TEST_VALUE));
+  }
+
+  @Benchmark
+  public void getEntropyBinary(Blackhole blackhole) {
+    blackhole.consume(ULID.getEntropyBinary(TEST_BINARY));
+  }
+
+  @Benchmark
+  public void toBinary(Blackhole blackhole) {
+    blackhole.consume(ULID.toBinary(TEST_VALUE));
+  }
+
+  @Benchmark
+  public void fromBinary(Blackhole blackhole) {
+    blackhole.consume(ULID.fromBinary(TEST_BINARY));
+  }
+
+  @Benchmark
+  public void newRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(new Random());
+  }
+
+  @Benchmark
+  public void newSecureRandom(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(new SecureRandom());
+  }
+
+  @Benchmark
+  public void threadLocalRandomCurrent(Blackhole blackhole, ULIDState state) {
+    blackhole.consume(ThreadLocalRandom.current());
   }
 }

--- a/src/test/java/io/azam/ulidj/ULIDTest.java
+++ b/src/test/java/io/azam/ulidj/ULIDTest.java
@@ -954,43 +954,6 @@ public class ULIDTest {
     }
     assertNotNull(noArgsCtor);
     assertFalse(noArgsCtor.isAccessible());
-    assertThrows("ULID constructor should throw IllegalAccessException",
-        IllegalAccessException.class, new ThrowingRunnable() {
-          @Override
-          public void run()
-              throws InvocationTargetException, InstantiationException, IllegalAccessException {
-            Constructor<?> testCtor = null;
-            for (Constructor<?> ctor : ULID.class.getDeclaredConstructors()) {
-              if (ctor.getParameterTypes().length == 0) {
-                testCtor = ctor;
-                break;
-              }
-            }
-            assert testCtor != null;
-            ULID value = ((Constructor<ULID>) testCtor).newInstance();
-          }
-        });
-    assertThrows("ULID constructor should throw UnsupportedOperationException if actually called",
-        UnsupportedOperationException.class, new ThrowingRunnable() {
-          @Override
-          public void run() throws Throwable {
-            Constructor<?> testCtor = null;
-            for (Constructor<?> ctor : ULID.class.getDeclaredConstructors()) {
-              if (ctor.getParameterTypes().length == 0) {
-                testCtor = ctor;
-                break;
-              }
-            }
-            assert testCtor != null;
-            testCtor.setAccessible(true);
-            try {
-              ULID value = ((Constructor<ULID>) testCtor).newInstance();
-            } catch (InvocationTargetException e) {
-              // unwrap the target exception
-              throw e.getTargetException();
-            }
-          }
-        });
   }
 
   @Test

--- a/src/test/java/io/azam/ulidj/ULIDTest.java
+++ b/src/test/java/io/azam/ulidj/ULIDTest.java
@@ -944,6 +944,24 @@ public class ULIDTest {
   }
 
   @Test
+  public void testULIDSort() {
+    ULID[] ulids = new ULID[TEST_PARAMETERS.length];
+    for (int i = 0; i < TEST_PARAMETERS.length; i++) {
+      ulids[i] = ULID.generateULID(TEST_PARAMETERS[i].timestamp, TEST_PARAMETERS[i].entropy);
+    }
+    Arrays.sort(ulids);
+    for (int i = 1; i < ulids.length; i++) {
+      if (ulids[i - 1].equals(ulids[i])) {
+        assertEquals("ULID " + ulids[i - 1] + " should be equal to " + ulids[i], 0,
+            ulids[i - 1].compareTo(ulids[i]));
+      } else {
+        assertTrue("ULID " + ulids[i - 1] + " should be lesser than " + ulids[i],
+            ulids[i - 1].compareTo(ulids[i]) < 0);
+      }
+    }
+  }
+
+  @Test
   public void testULIDNew() {
     Constructor<?>[] ctors = ULID.class.getConstructors();
     Constructor<?> noArgsCtor = null;

--- a/src/test/java/io/azam/ulidj/ULIDTest.java
+++ b/src/test/java/io/azam/ulidj/ULIDTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -944,7 +945,7 @@ public class ULIDTest {
 
   @Test
   public void testULIDNew() {
-    Constructor<?>[] ctors = ULID.class.getDeclaredConstructors();
+    Constructor<?>[] ctors = ULID.class.getConstructors();
     Constructor<?> noArgsCtor = null;
     for (Constructor<?> ctor : ctors) {
       if (ctor.getParameterTypes().length == 0) {
@@ -952,8 +953,7 @@ public class ULIDTest {
         break;
       }
     }
-    assertNotNull(noArgsCtor);
-    assertFalse(noArgsCtor.isAccessible());
+    assertNull("ULID class should not have a no-args constructor", noArgsCtor);
   }
 
   @Test

--- a/src/test/java/io/azam/ulidj/UUIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/UUIDBenchmark.java
@@ -1,0 +1,20 @@
+package io.azam.ulidj;
+
+import java.util.UUID;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class UUIDBenchmark {
+  public static final String TEST_VALUE = "00526084-9560-7fff-ffff-ffffffffffff";
+
+  @Benchmark
+  public void randomUUID(Blackhole blackhole) {
+    blackhole.consume(UUID.randomUUID());
+  }
+
+  @Benchmark
+  public void fromString(Blackhole blackhole) {
+    blackhole.consume(UUID.fromString(TEST_VALUE));
+  }
+}

--- a/src/test/java/io/azam/ulidj/UUIDBenchmark.java
+++ b/src/test/java/io/azam/ulidj/UUIDBenchmark.java
@@ -1,3 +1,23 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2025 Azamshul Azizy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package io.azam.ulidj;
 
 import java.util.UUID;


### PR DESCRIPTION
* Breaking changes
  * `ULID` and `MonotonicULID` are now `final` classes
  * These methods now check for ULID validity and throws `IllegalArgumentException` if not valid
    * `ULID.generate(long,byte[])`
    * `ULID.generateBinary(long,byte[])`
    * `ULID.getTimestamp(CharSequence)`
    * `ULID.getTimestampBinary(byte[])`
    * `ULID.getEntropy(CharSequence)`
    * `ULID.getEntropyBinary(byte[])`
    * `ULID.toBinary(CharSequence)`
    * `ULID.fromBinary(byte[])`

* New features
  * Immutable, sortable `ULID` instance, instantiable from the following methods
    * `ULID.randomULID()`
    * `ULID.randomULID(Random)`
    * `ULID.parseULID(CharSequence)`
    * `ULID.parseULID(byte[])`
    * `ULID.generateULID(long,byte[])`
    * `MonotonicULID.randomULID()`
  * Static method on `MonotonicULID` to generate ULID values from a default singleton `MonotonicULID` instance
    * `MonotonicULID.random()`
    * `MonotonicULID.randomBinary()`
    * `MonotonicULID.randomULID()`

* Improvements
  * These methods now uses a static lazily instantiated instance of `java.security.SecureRandom` for performance
    * `ULID.random()`
    * `ULID.randomBinary()`
    * `new MonotonicULID()`
  * Fix `MonotonicULID` last entropy increment being persisted on entropy overflow

* Project
  * Added JaCoCo
  * Added Maven site generation
  * Updated documentation